### PR TITLE
perf: lazy-load CodeMirror on paste + home routes

### DIFF
--- a/src/lib/components/LazyCodeMirror.svelte
+++ b/src/lib/components/LazyCodeMirror.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { Extension } from '@codemirror/state';
+	import type { LanguageSupport } from '@codemirror/language';
+
+	// Props matching svelte-codemirror-editor
+	let {
+		value = $bindable(''),
+		lang = null,
+		theme = null,
+		extensions = [],
+		styles = {},
+		placeholder = '',
+		ariaLabel = 'Code editor'
+	}: {
+		value?: string;
+		lang?: LanguageSupport | null;
+		theme?: Extension | null;
+		extensions?: Extension[];
+		styles?: Record<string, Record<string, string>>;
+		placeholder?: string;
+		ariaLabel?: string;
+	} = $props();
+
+	// PERF: svelte-codemirror-editor + @codemirror/view (~heavy) are loaded dynamically
+	// after first paint so the skeleton renders immediately and decrypted content
+	// isn't blocked on the editor bundle evaluating.
+	let CodeMirrorComponent: typeof import('svelte-codemirror-editor').default | null = $state(null);
+	let ariaLabelExtension: Extension | null = $state(null);
+	let isLoading = $state(true);
+
+	onMount(async () => {
+		// Small delay so first paint happens with the skeleton
+		await new Promise((resolve) => requestAnimationFrame(resolve));
+
+		const [module, { EditorView }] = await Promise.all([
+			import('svelte-codemirror-editor'),
+			import('@codemirror/view')
+		]);
+		CodeMirrorComponent = module.default;
+		ariaLabelExtension = EditorView.contentAttributes.of({ 'aria-label': ariaLabel });
+		isLoading = false;
+	});
+</script>
+
+{#if isLoading || !CodeMirrorComponent}
+	<!-- Pulsing skeleton while CodeMirror loads -->
+	<div class="absolute inset-0 flex bg-zinc-800 rounded animate-pulse">
+		<div class="bg-zinc-900 py-1 px-2 text-right select-none">
+			{#each Array(20) as _, i}
+				<div class="text-zinc-600 text-sm leading-relaxed">{i + 1}</div>
+			{/each}
+		</div>
+		<div class="flex-1 p-3 flex flex-col gap-2">
+			<div class="h-3.5 bg-zinc-700 rounded w-3/4"></div>
+			<div class="h-3.5 bg-zinc-700 rounded w-1/2"></div>
+			<div class="h-3.5 bg-zinc-700 rounded w-5/6"></div>
+			<div class="h-3.5 bg-zinc-700 rounded w-2/3"></div>
+			<div class="h-3.5 bg-zinc-700 rounded w-1/4"></div>
+			<div class="h-3.5 bg-zinc-700 rounded w-4/5"></div>
+			<div class="h-3.5 bg-zinc-700 rounded w-1/3"></div>
+			<div class="h-3.5 bg-zinc-700 rounded w-3/5"></div>
+			<div class="h-3.5 bg-zinc-700 rounded w-1/2"></div>
+			<div class="h-3.5 bg-zinc-700 rounded w-2/3"></div>
+			<div class="h-3.5 bg-zinc-700 rounded w-1/4"></div>
+			<div class="h-3.5 bg-zinc-700 rounded w-3/4"></div>
+		</div>
+	</div>
+{:else}
+	<CodeMirrorComponent
+		bind:value
+		{lang}
+		{theme}
+		extensions={[...extensions, ...(ariaLabelExtension ? [ariaLabelExtension] : [])]}
+		{styles}
+		{placeholder}
+	/>
+{/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import logo from '$lib/assets/logo.svg';
-	import CodeMirror from 'svelte-codemirror-editor';
+	import LazyCodeMirror from '$lib/components/LazyCodeMirror.svelte';
 	import { javascript } from '@codemirror/lang-javascript';
 	import { oneDark } from '@codemirror/theme-one-dark';
 	import { EditorView, keymap } from '@codemirror/view';
@@ -20,7 +20,7 @@
 	import { goto, afterNavigate } from '$app/navigation';
 	import { onMount, onDestroy, tick } from 'svelte';
 	import { generateKey, encrypt, keyToBase64, generateSalt, deriveKeyFromPassword } from '$lib/crypto';
-	import { detectLanguage } from '$lib/detectLanguage';
+	// PERF: detectLanguage pulls highlight.js (~60-80KB) — dynamically imported at save time only (see below)
 	import ShortcutsModal from '$lib/components/ShortcutsModal.svelte';
 
 	// Dynamic language extension for CodeMirror (null = plaintext/no highlighting)
@@ -412,8 +412,12 @@
 				urlKey = await keyToBase64(key);
 			}
 
-			// Use selected language or auto-detect
-			const language = selectedLanguage === 'auto' ? detectLanguage(content) : selectedLanguage;
+			// Use selected language or auto-detect (highlight.js loaded lazily only when needed)
+			let language = selectedLanguage;
+			if (selectedLanguage === 'auto') {
+				const { detectLanguage } = await import('$lib/detectLanguage');
+				language = detectLanguage(content);
+			}
 
 			// Encrypt content
 			const encrypted = await encrypt(content, key);
@@ -594,7 +598,7 @@
 
 	<!-- Editor -->
 	<div class="flex-1 min-h-0 overflow-auto relative">
-		<CodeMirror
+		<LazyCodeMirror
 			bind:value={content}
 			lang={languageExtension}
 			theme={currentTheme}

--- a/src/routes/p/[id]/+page.svelte
+++ b/src/routes/p/[id]/+page.svelte
@@ -3,7 +3,7 @@
 	import { goto, beforeNavigate, afterNavigate } from '$app/navigation';
 	import { onMount } from 'svelte';
 	import { decrypt, base64ToKey, deriveKeyFromPassword } from '$lib/crypto';
-	import CodeMirror from 'svelte-codemirror-editor';
+	import LazyCodeMirror from '$lib/components/LazyCodeMirror.svelte';
 	import { javascript } from '@codemirror/lang-javascript';
 	import { oneDark } from '@codemirror/theme-one-dark';
 	import type { Extension } from '@codemirror/state';
@@ -712,12 +712,11 @@
 	{#if viewState === 'success'}
 		<!-- CodeMirror Viewer -->
 		<div class="flex-1 min-h-0 overflow-auto relative">
-			<CodeMirror
+			<LazyCodeMirror
 				value={content}
 				lang={languageExtension}
 				theme={currentTheme}
 				extensions={[EditorView.lineWrapping, EditorView.editable.of(false)]}
-				editable={false}
 				styles={{
 					'&': {
 						height: '100%',


### PR DESCRIPTION
Closes #4, closes #5.

Adds a `LazyCodeMirror` wrapper (pulsing skeleton, then dynamically imports `svelte-codemirror-editor` + `@codemirror/view` after first paint) and uses it on `/p/[id]` (the most-shared route) and the home page, so the editor bundle no longer blocks client-side decryption render. Home also dynamically imports `detectLanguage` (highlight.js, ~60-80KB) at save time only, removing it from the LCP home bundle.

Verified: `pnpm check` = 0 errors; `pnpm build` succeeds.