### PR TITLE
docs: SECURITY.md + security.txt + verify-zero-knowledge guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ The encryption key lives in the URL fragment (`#`), which **browsers never send 
 - **Key Derivation**: PBKDF2 with 100,000 iterations (for password-protected pastes)
 - **Random Generation**: Web Crypto API (`crypto.getRandomValues`)
 
+## Verify the Zero-Knowledge Claim Yourself
+
+Don't take our word for it — the guarantee is verifiable in your browser:
+
+1. Open your browser's **DevTools** (F12) and switch to the **Network** tab.
+2. Type some text and **create a paste**.
+3. Inspect the outgoing `POST` request that saves the paste and look at its **request body**. You'll see only **ciphertext** and a **salt** — never your plaintext, and never the encryption key.
+4. Look at the resulting paste URL: the decryption key is the part after the `#` (the **URL fragment**). By web standard, browsers **never send the fragment to the server** — it stays client-side.
+5. Open the paste and watch the Network tab again: the server returns the stored **ciphertext**, and decryption happens **in your browser** using the key from the `#fragment`.
+
+Because the key only ever exists in the fragment and in your recipient's browser, the server (and its database, and anyone on the network) only ever sees encrypted blobs. There is no server-side code path that can read your content — even under subpoena, only ciphertext exists to hand over.
+
 ## Features
 
 - 🔐 **Zero-Knowledge Encryption** - AES-256-GCM, keys never leave your browser

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+CloakBin is a **zero-knowledge encrypted pastebin**: encryption happens in the browser and the decryption key lives only in the URL `#fragment`, so the server ever only stores ciphertext. Because privacy is the entire point of the project, we treat any issue that could leak plaintext, keys, or user data — or that weakens the client-side cryptography — as **high priority**.
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities **privately** — do not open a public issue for a security bug.
+
+- **Preferred:** open a private report via GitHub Security Advisories:
+  <https://github.com/Ishannaik/CloakBin/security/advisories/new>
+- **Email:** `security@cloakbin.com`
+
+Please include: a description of the issue, steps to reproduce (or a proof of concept), the affected file/endpoint if known, and the potential impact.
+
+## Scope
+
+In scope:
+- The CloakBin application (this repository) and its API endpoints.
+- The client-side cryptography and the zero-knowledge guarantee (any path where plaintext, the encryption key, or the URL fragment could reach the server or a third party).
+- Authentication/authorization, injection, and data-exposure issues.
+
+Out of scope:
+- Vulnerabilities in third-party dependencies without a demonstrated impact on CloakBin (report those upstream, but feel free to flag them).
+- Findings that require a compromised end-user device or browser.
+
+## Supported Versions
+
+Security fixes are applied to the latest `main` branch and the most recent tagged release. Please verify an issue against the latest `main` before reporting.
+
+## Response
+
+We aim to acknowledge a valid report within a few days and to address confirmed high-impact issues promptly. We're happy to credit reporters in the release notes unless you prefer to remain anonymous.

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,8 +1,10 @@
+Contact: https://github.com/Ishannaik/CloakBin/security/advisories/new
 Contact: mailto:security@cloakbin.com
 Preferred-Languages: en
-Canonical: https://cloakbin.com/.well-known/security.txt
-Expires: 2026-12-31T23:59:59.000Z
+Canonical: https://oss.cloakbin.com/.well-known/security.txt
+Expires: 2027-07-11T00:00:00.000Z
 
 # CloakBin Security Policy
-# We take security seriously. If you find a vulnerability,
-# please report it responsibly to the email above.
+# CloakBin is a zero-knowledge encrypted pastebin. Please report
+# vulnerabilities responsibly via the GitHub advisory link above
+# (preferred) or the security@ email. See SECURITY.md for scope.


### PR DESCRIPTION
Closes #8. Adds a responsible-disclosure policy (SECURITY.md), refreshes RFC 9116 security.txt (GitHub advisory contact, oss.cloakbin.com canonical, extended expiry), and a README section showing readers how to verify the zero-knowledge claim in DevTools. Privacy-Guides eligibility polish. Docs-only.