### PR TITLE
test: admin session auth (forgery rejection, constant-time compare)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 		"format:check": "prettier --check .",
 		"generate:assets": "node generate-assets.mjs && node generate-extra-assets.mjs",
 		"generate:assets:main": "node generate-assets.mjs",
-		"generate:assets:extra": "node generate-extra-assets.mjs"
+		"generate:assets:extra": "node generate-extra-assets.mjs",
+		"test": "vitest run"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
@@ -43,7 +44,8 @@
 		"tailwindcss": "^4.1.17",
 		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.63.0",
-		"vite": "^7.2.2"
+		"vite": "^7.2.2",
+		"vitest": "^4.1.10"
 	},
 	"dependencies": {
 		"@codemirror/lang-cpp": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       vite:
         specifier: ^7.2.2
         version: 7.2.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.30.2)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(vite@7.2.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.30.2))
 
 packages:
 
@@ -779,6 +782,9 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@sveltejs/acorn-typescript@1.0.8':
     resolution: {integrity: sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==}
     peerDependencies:
@@ -914,8 +920,14 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1050,6 +1062,35 @@ packages:
     resolution: {integrity: sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1073,6 +1114,10 @@ packages:
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1103,6 +1148,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1127,6 +1176,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
@@ -1170,6 +1222,9 @@ packages:
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
+
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1247,9 +1302,16 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1567,6 +1629,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1590,6 +1656,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1692,6 +1761,9 @@ packages:
   sift@17.1.3:
     resolution: {integrity: sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -1702,6 +1774,12 @@ packages:
 
   sparse-bitfield@3.0.3:
     resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1760,9 +1838,20 @@ packages:
       '@codemirror/state': ^6.0.0
       '@codemirror/view': ^6.0.0
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -1864,6 +1953,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -1878,6 +2008,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2482,6 +2617,8 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@sveltejs/acorn-typescript@1.0.8(acorn@8.15.0)':
     dependencies:
       acorn: 8.15.0
@@ -2611,7 +2748,14 @@ snapshots:
       tailwindcss: 4.1.17
       vite: 7.2.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.30.2)
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/cookie@0.6.0': {}
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2810,6 +2954,47 @@ snapshots:
       '@typescript-eslint/types': 8.63.0
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@7.2.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.30.2))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.2.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.30.2)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -2830,6 +3015,8 @@ snapshots:
   argparse@2.0.1: {}
 
   aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
 
   axobject-query@4.1.0: {}
 
@@ -2853,6 +3040,8 @@ snapshots:
   bson@7.0.0: {}
 
   callsites@3.1.0: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -2883,6 +3072,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie@0.6.0: {}
 
   crelt@1.0.6: {}
@@ -2911,6 +3102,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  es-module-lexer@2.3.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -3041,7 +3234,13 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3274,6 +3473,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  obug@2.1.3: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3298,6 +3499,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -3421,6 +3624,8 @@ snapshots:
 
   sift@17.1.3: {}
 
+  siginfo@2.0.0: {}
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -3432,6 +3637,10 @@ snapshots:
   sparse-bitfield@3.0.3:
     dependencies:
       memory-pager: 1.5.0
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -3502,10 +3711,16 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.8
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
 
   totalist@3.0.1: {}
 
@@ -3575,6 +3790,33 @@ snapshots:
     optionalDependencies:
       vite: 7.2.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.30.2)
 
+  vitest@4.1.10(@types/node@26.1.1)(vite@7.2.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.30.2)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.2.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.2.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.30.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.1.1
+    transitivePeerDependencies:
+      - msw
+
   w3c-keyname@2.2.8: {}
 
   webidl-conversions@7.0.0: {}
@@ -3587,6 +3829,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,7 +5,7 @@
 
 import type { Handle } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
-import { createHmac, timingSafeEqual } from 'crypto';
+import { verifyAdminSession } from '$lib/server/admin-auth';
 
 // ============================================
 // RATE LIMITING (In-Memory)
@@ -131,33 +131,9 @@ export const handle: Handle = async ({ event, resolve }) => {
 	// ADMIN SESSION CHECK
 	// ============================================
 	const adminSession = event.cookies.get('admin_session');
-	if (adminSession && env.ADMIN_PASS) {
-		try {
-			const decoded = Buffer.from(adminSession, 'base64').toString('utf-8');
-			const parts = decoded.split(':');
-			// Token format: timestamp:username:hmac_hex
-			if (parts.length === 3) {
-				const [timestamp, username, providedSig] = parts;
-				const sessionAge = Date.now() - parseInt(timestamp, 10);
-				const MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
-
-				if (username === env.ADMIN_USER && sessionAge >= 0 && sessionAge < MAX_AGE) {
-					// Recompute HMAC and verify with timing-safe comparison
-					const expectedSig = createHmac('sha256', env.ADMIN_PASS)
-						.update(timestamp + ':' + username)
-						.digest('hex');
-					const sigBuffer = Buffer.from(providedSig, 'utf-8');
-					const expectedBuffer = Buffer.from(expectedSig, 'utf-8');
-					if (
-						sigBuffer.length === expectedBuffer.length &&
-						timingSafeEqual(sigBuffer, expectedBuffer)
-					) {
-						event.locals.isAdmin = true;
-					}
-				}
-			}
-		} catch {
-			// Invalid session format - ignore
+	if (adminSession && env.ADMIN_USER && env.ADMIN_PASS) {
+		if (verifyAdminSession(adminSession, env.ADMIN_USER, env.ADMIN_PASS)) {
+			event.locals.isAdmin = true;
 		}
 	}
 

--- a/src/lib/server/admin-auth.test.ts
+++ b/src/lib/server/admin-auth.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { safeEqual, signAdminSession, verifyAdminSession } from './admin-auth';
+
+const SECRET = 'super-secret-admin-pass';
+const USER = 'admin';
+const DAY = 24 * 60 * 60 * 1000;
+const T = 1_700_000_000_000; // fixed reference time for deterministic tests
+
+describe('safeEqual (constant-time compare)', () => {
+	it('is true for equal strings', () => {
+		expect(safeEqual('correct-horse', 'correct-horse')).toBe(true);
+	});
+	it('is false for different strings of equal length', () => {
+		expect(safeEqual('abcdef', 'abcxef')).toBe(false);
+	});
+	it('is false for different lengths (no length leak / no throw)', () => {
+		expect(safeEqual('abc', 'abcdef')).toBe(false);
+	});
+	it('is true for two empty strings', () => {
+		expect(safeEqual('', '')).toBe(true);
+	});
+});
+
+describe('admin session sign/verify', () => {
+	it('round-trips a freshly signed token', () => {
+		const token = signAdminSession(USER, SECRET, T);
+		expect(verifyAdminSession(token, USER, SECRET, DAY, T + 1000)).toBe(true);
+	});
+
+	it('rejects a forged token with a bogus signature (the lissy93 attack)', () => {
+		// btoa("admin:<now>") style forgery — attacker knows the username but not the HMAC.
+		const forged = Buffer.from(T + ':' + USER + ':' + 'deadbeefdeadbeef').toString('base64');
+		expect(verifyAdminSession(forged, USER, SECRET, DAY, T + 1000)).toBe(false);
+	});
+
+	it('rejects a token with no signature part at all (only 2 fields)', () => {
+		const forged = Buffer.from(T + ':' + USER).toString('base64');
+		expect(verifyAdminSession(forged, USER, SECRET, DAY, T + 1000)).toBe(false);
+	});
+
+	it('rejects a tampered signature (flipped char, same length)', () => {
+		const token = signAdminSession(USER, SECRET, T);
+		const [ts, user, sig] = Buffer.from(token, 'base64').toString('utf-8').split(':');
+		const flipped = sig.slice(0, -1) + (sig.slice(-1) === 'a' ? 'b' : 'a');
+		const tampered = Buffer.from(ts + ':' + user + ':' + flipped).toString('base64');
+		expect(verifyAdminSession(tampered, USER, SECRET, DAY, T + 1000)).toBe(false);
+	});
+
+	it('rejects verification under the wrong secret', () => {
+		const token = signAdminSession(USER, SECRET, T);
+		expect(verifyAdminSession(token, USER, 'different-secret', DAY, T + 1000)).toBe(false);
+	});
+
+	it('rejects an expired token', () => {
+		const token = signAdminSession(USER, SECRET, T);
+		// age = 5000ms, maxAge = 1000ms
+		expect(verifyAdminSession(token, USER, SECRET, 1000, T + 5000)).toBe(false);
+	});
+
+	it('rejects a future-dated token (negative age)', () => {
+		const token = signAdminSession(USER, SECRET, T + 10_000);
+		expect(verifyAdminSession(token, USER, SECRET, DAY, T)).toBe(false);
+	});
+
+	it('rejects the wrong username', () => {
+		const token = signAdminSession(USER, SECRET, T);
+		expect(verifyAdminSession(token, 'attacker', SECRET, DAY, T + 1000)).toBe(false);
+	});
+
+	it('rejects garbage / empty input without throwing', () => {
+		expect(verifyAdminSession('', USER, SECRET, DAY, T)).toBe(false);
+		expect(verifyAdminSession('%%%not-base64%%%', USER, SECRET, DAY, T)).toBe(false);
+	});
+});

--- a/src/lib/server/admin-auth.ts
+++ b/src/lib/server/admin-auth.ts
@@ -1,0 +1,70 @@
+/**
+ * Admin session authentication — HMAC-signed cookie tokens.
+ *
+ * Extracted from admin/login/+page.server.ts (signing) and hooks.server.ts
+ * (verification) so the security-critical logic is testable. Behaviour is
+ * intentionally identical to the original inline code.
+ *
+ * Token format: base64("<timestamp>:<username>:<hmac_hex>")
+ * where hmac = HMAC-SHA256(secret, "<timestamp>:<username>"), secret = ADMIN_PASS.
+ */
+import { createHmac, createHash, timingSafeEqual } from 'crypto';
+
+/** 24 hours — the admin session lifetime. */
+export const ADMIN_SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Constant-time string comparison. Both sides are hashed to fixed 32-byte
+ * buffers so timingSafeEqual gets equal-length inputs (no length leak) and the
+ * comparison runs in constant time regardless of where the strings differ.
+ */
+export function safeEqual(a: string, b: string): boolean {
+	const ha = createHash('sha256').update(a).digest();
+	const hb = createHash('sha256').update(b).digest();
+	return timingSafeEqual(ha, hb);
+}
+
+/** Build a signed admin session token. `now` is injectable for testing. */
+export function signAdminSession(username: string, secret: string, now: number = Date.now()): string {
+	const payload = now + ':' + username;
+	const signature = createHmac('sha256', secret).update(payload).digest('hex');
+	return Buffer.from(payload + ':' + signature).toString('base64');
+}
+
+/**
+ * Verify an admin session token. Returns true only when the token is a
+ * well-formed, non-expired token for `expectedUser` whose HMAC signature
+ * matches (constant-time). Any malformed/forged/tampered/expired token → false.
+ * `now` is injectable for testing.
+ */
+export function verifyAdminSession(
+	token: string,
+	expectedUser: string,
+	secret: string,
+	maxAgeMs: number = ADMIN_SESSION_MAX_AGE_MS,
+	now: number = Date.now()
+): boolean {
+	try {
+		const decoded = Buffer.from(token, 'base64').toString('utf-8');
+		const parts = decoded.split(':');
+		// Token format: timestamp:username:hmac_hex
+		if (parts.length !== 3) return false;
+		const [timestamp, username, providedSig] = parts;
+
+		const sessionAge = now - parseInt(timestamp, 10);
+		if (!(username === expectedUser && sessionAge >= 0 && sessionAge < maxAgeMs)) {
+			return false;
+		}
+
+		// Recompute HMAC and compare in constant time.
+		const expectedSig = createHmac('sha256', secret)
+			.update(timestamp + ':' + username)
+			.digest('hex');
+		const sigBuffer = Buffer.from(providedSig, 'utf-8');
+		const expectedBuffer = Buffer.from(expectedSig, 'utf-8');
+		return sigBuffer.length === expectedBuffer.length && timingSafeEqual(sigBuffer, expectedBuffer);
+	} catch {
+		// Invalid base64 / parse error → not authenticated.
+		return false;
+	}
+}

--- a/src/routes/admin/login/+page.server.ts
+++ b/src/routes/admin/login/+page.server.ts
@@ -1,15 +1,7 @@
 import { redirect, fail } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
-import { createHmac, createHash, timingSafeEqual } from 'crypto';
+import { safeEqual, signAdminSession } from '$lib/server/admin-auth';
 import type { Actions, PageServerLoad } from './$types';
-
-function safeEqual(a: string, b: string): boolean {
-	// Hash both sides to fixed 32-byte buffers so timingSafeEqual gets equal-length
-	// inputs (no length leak) and the comparison runs in constant time.
-	const ha = createHash('sha256').update(a).digest();
-	const hb = createHash('sha256').update(b).digest();
-	return timingSafeEqual(ha, hb);
-}
 
 export const load: PageServerLoad = async ({ locals }) => {
 	// If already logged in, redirect to admin
@@ -49,10 +41,7 @@ export const actions: Actions = {
 		}
 
 		// Create HMAC-signed session token
-		const timestamp = Date.now();
-		const payload = timestamp + ':' + username;
-		const signature = createHmac('sha256', adminPass).update(payload).digest('hex');
-		const sessionToken = Buffer.from(payload + ':' + signature).toString('base64');
+		const sessionToken = signAdminSession(username, adminPass);
 
 		cookies.set('admin_session', sessionToken, {
 			path: '/',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+// Isolated unit-test config (does not load the SvelteKit vite plugin).
+// Tests target pure server modules with no $app/$env aliases.
+export default defineConfig({
+	test: {
+		environment: 'node',
+		include: ['src/**/*.{test,spec}.ts']
+	}
+});


### PR DESCRIPTION
Closes #9. Extracts admin session sign/verify + `safeEqual` into a testable `$lib/server/admin-auth` module (behaviour unchanged — same token format + verification), wired into both admin/login and hooks.server.ts. Adds vitest + 13 unit tests proving forged/tampered/expired/wrong-secret/wrong-user tokens are rejected and the credential compare is constant-time. pnpm check 0 errors, build green, 13/13 tests pass.