### PR TITLE
ui: match hosted paste options

### DIFF
--- a/src/lib/components/ExpirySelect.svelte
+++ b/src/lib/components/ExpirySelect.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import { Clock, Infinity as InfinityIcon } from 'lucide-svelte';
+	import { slide } from 'svelte/transition';
+
+	let {
+		value = $bindable('1h'),
+		options
+	}: {
+		value?: string;
+		options: { value: string; label: string }[];
+	} = $props();
+
+	let open = $state(false);
+	let root: HTMLDivElement | undefined = $state();
+
+	const selectedLabel = $derived(options.find((o) => o.value === value)?.label ?? value);
+
+	function select(v: string) {
+		value = v;
+		open = false;
+	}
+
+	function onWindowClick(e: MouseEvent) {
+		if (open && root && !root.contains(e.target as Node)) open = false;
+	}
+
+	function onKey(e: KeyboardEvent) {
+		if (e.key === 'Escape') open = false;
+	}
+</script>
+
+<svelte:window onclick={onWindowClick} onkeydown={onKey} />
+
+<div class="relative shrink-0" bind:this={root}>
+	<button
+		type="button"
+		onclick={() => (open = !open)}
+		aria-haspopup="listbox"
+		aria-expanded={open}
+		aria-label="Paste expiry"
+		class="flex items-center gap-1.5 h-8 min-w-[7rem] px-2.5 bg-bg-secondary border border-zinc-700 rounded text-zinc-200 text-sm transition-colors hover:border-zinc-500 focus:outline-none focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20"
+	>
+		{#if value === 'never'}
+			<InfinityIcon class="size-3.5 text-amber-400" />
+		{:else}
+			<Clock class="size-3.5 text-zinc-400" />
+		{/if}
+		<span class="flex-1 text-left">{selectedLabel}</span>
+		<svg
+			class="size-3.5 text-zinc-500 transition-transform duration-150 {open ? 'rotate-180' : ''}"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg
+		>
+	</button>
+
+	{#if open}
+		<div
+			transition:slide={{ duration: 150 }}
+			role="listbox"
+			tabindex="-1"
+			class="absolute bottom-full mb-1.5 left-0 w-max min-w-full bg-zinc-800 border border-zinc-700 rounded shadow-xl overflow-hidden z-50 py-1"
+		>
+			{#each options as option}
+				<button
+					type="button"
+					role="option"
+					aria-selected={option.value === value}
+					onclick={() => select(option.value)}
+					class="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-left transition-colors hover:bg-zinc-700 {option.value ===
+					value
+						? 'text-teal-400'
+						: 'text-zinc-300'}"
+				>
+					{#if option.value === 'never'}
+						<InfinityIcon class="size-3.5 text-amber-400" />
+					{:else}
+						<Clock class="size-3.5 text-zinc-500" />
+					{/if}
+					<span class="flex-1">{option.label}</span>
+					{#if option.value === value}
+						<span class="text-teal-400">✓</span>
+					{/if}
+				</button>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import logo from '$lib/assets/logo.svg';
 	import LazyCodeMirror from '$lib/components/LazyCodeMirror.svelte';
+	import ExpirySelect from '$lib/components/ExpirySelect.svelte';
 	import { javascript } from '@codemirror/lang-javascript';
 	import { oneDark } from '@codemirror/theme-one-dark';
 	import { EditorView, keymap } from '@codemirror/view';
@@ -618,17 +619,7 @@
 
 	<!-- Bottom bar -->
 	<div class="flex flex-wrap items-center justify-center gap-2 sm:gap-4 px-4 py-3 sm:py-4 border-t border-zinc-800">
-		<div class="flex items-center gap-2">
-			<span class="text-zinc-500 text-sm hidden sm:inline">Expiry:</span>
-			<select
-				bind:value={expiry}
-				class="bg-bg-secondary border border-zinc-700 rounded px-2 sm:px-3 py-2 text-sm cursor-pointer transition-all duration-150 hover:border-zinc-500 focus:outline-none focus:border-teal-500 focus:ring-2 focus:ring-teal-500/20"
-			>
-				{#each expiryOptions as option}
-					<option value={option.value}>{option.label}</option>
-				{/each}
-			</select>
-		</div>
+		<ExpirySelect bind:value={expiry} options={expiryOptions} />
 		<!-- Password toggle -->
 		<label class="flex items-center gap-1.5 cursor-pointer">
 			<input
@@ -636,14 +627,15 @@
 				bind:checked={usePassword}
 				class="w-4 h-4 cursor-pointer appearance-none rounded border border-zinc-600 bg-zinc-800 checked:bg-teal-500 checked:border-teal-500 relative checked:after:content-['✓'] checked:after:absolute checked:after:inset-0 checked:after:flex checked:after:items-center checked:after:justify-center checked:after:text-[10px] checked:after:text-zinc-900 checked:after:font-bold"
 			/>
+			<Lock size={14} class="text-zinc-400" />
 			<span class="text-zinc-400 text-sm hidden sm:inline">Password</span>
-			<Lock size={14} class="text-zinc-400 sm:hidden" />
 		</label>
 		{#if usePassword}
 			<input
 				type="password"
 				bind:value={password}
 				placeholder="Password..."
+				maxlength={128}
 				class="bg-bg-secondary border border-zinc-700 rounded px-2 py-2 text-sm w-24 sm:w-32 focus:outline-none focus:border-teal-500"
 			/>
 		{/if}
@@ -654,8 +646,8 @@
 				bind:checked={burnAfterRead}
 				class="w-4 h-4 cursor-pointer appearance-none rounded border border-zinc-600 bg-zinc-800 checked:bg-orange-500 checked:border-orange-500 relative checked:after:content-['✓'] checked:after:absolute checked:after:inset-0 checked:after:flex checked:after:items-center checked:after:justify-center checked:after:text-[10px] checked:after:text-zinc-900 checked:after:font-bold"
 			/>
+			<span class="text-orange-500">🔥</span>
 			<span class="text-zinc-400 text-sm hidden sm:inline">Burn</span>
-			<span class="text-orange-500 sm:hidden">🔥</span>
 		</label>
 		<!-- Primary: Create -->
 		<button


### PR DESCRIPTION
Brings the OSS create/options bar in line with the hosted app:
- **Expiry:** replaces the plain native `<select>` with an animated custom dropdown (`ExpirySelect.svelte`) — Clock/Infinity lucide icon in the trigger, a menu that opens with Svelte's `transition:slide`, per-option icons, and a teal ✓ on the selected option. No bits-ui dependency (kept lean).
- **Password / Burn toggles:** show the Lock 🔒 and 🔥 icons **always** (were only visible at the `sm` breakpoint) to match hosted; added `maxlength={128}` on the password input.

No premium/paid UI (no custom-URL, Crown, retention/upgrade CTAs). No legal footer added — the OSS app has no content pages, so those links would 404; the create-page 'footer' is this options bar. pnpm check 0 errors, build green.