### PR TITLE
ui: encryption banner + encrypt animation + footer

### DIFF
--- a/src/lib/components/EncryptionBanner.svelte
+++ b/src/lib/components/EncryptionBanner.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { Lock, X } from 'lucide-svelte';
+	import { slide } from 'svelte/transition';
+	import { browser } from '$app/environment';
+
+	// Dismissed state persisted in localStorage (OSS has no preferences store)
+	let dismissed = $state(browser && localStorage.getItem('encryptionBannerDismissed') === 'true');
+
+	function handleDismiss() {
+		dismissed = true;
+		if (browser) localStorage.setItem('encryptionBannerDismissed', 'true');
+	}
+</script>
+
+{#if !dismissed}
+	<div
+		class="w-full bg-teal-500/10 border-b border-teal-500/20 px-3 sm:px-4 py-2"
+		transition:slide={{ duration: 200 }}
+	>
+		<div class="flex items-center justify-center gap-2 sm:gap-3 text-sm">
+			<Lock class="w-4 h-4 text-teal-400 shrink-0" />
+			<span class="text-teal-200">
+				<span class="font-medium">We can't read your pastes.</span>
+				<span class="text-teal-200/70 hidden sm:inline"> Encrypted in your browser.</span>
+			</span>
+			<a
+				href="https://github.com/Ishannaik/CloakBin#readme"
+				target="_blank"
+				rel="noopener"
+				class="text-teal-400 hover:text-teal-300 transition-colors text-xs sm:text-sm"
+			>
+				Learn more
+			</a>
+			<button
+				onclick={handleDismiss}
+				class="text-teal-400/60 hover:text-teal-400 transition-colors p-0.5 -mr-1"
+				aria-label="Dismiss"
+			>
+				<X class="w-4 h-4" />
+			</button>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/EncryptionOverlay.svelte
+++ b/src/lib/components/EncryptionOverlay.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import { Lock } from 'lucide-svelte';
+	import { browser } from '$app/environment';
+	import { untrack } from 'svelte';
+	import { startCipherMorph } from '$lib/utils/cipher-morph';
+
+	interface Props {
+		active: boolean;
+		sourceText: string;
+		encryptedText: string;
+		onFrame?: (text: string) => void;
+	}
+
+	let { active, sourceText, encryptedText, onFrame }: Props = $props();
+
+	let showOverlay = $state(false);
+
+	// Morph animation — drives the editor's value via onFrame callback
+	$effect(() => {
+		if (!browser || !active) return;
+
+		showOverlay = true;
+
+		// Snapshot source text WITHOUT tracking — content gets cleared
+		// after the API call and we don't want that to restart the animation
+		const source = untrack(() => sourceText);
+
+		// Track encryptedText — starts empty, effect re-runs when ciphertext arrives
+		if (!encryptedText) return;
+
+		return startCipherMorph(source, encryptedText, (text) => {
+			onFrame?.(text);
+		});
+	});
+
+	// Keep overlay in DOM during fade-out transition
+	$effect(() => {
+		if (!active && showOverlay) {
+			const id = setTimeout(() => (showOverlay = false), 200);
+			return () => clearTimeout(id);
+		}
+	});
+</script>
+
+{#if showOverlay}
+	<div
+		class="absolute inset-0 z-20 flex items-center justify-center transition-opacity duration-200 pointer-events-none"
+		class:opacity-100={active}
+		class:opacity-0={!active}
+		role="status"
+		aria-live="polite"
+		aria-label="Encrypting your content"
+	>
+		<div
+			class="relative flex items-center gap-2 px-4 py-2 bg-zinc-900/80 rounded-lg border border-teal-500/30 backdrop-blur-sm"
+		>
+			<Lock size={16} class="text-teal-400" />
+			<span class="text-teal-400 text-sm font-medium">Encrypting...</span>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -1,0 +1,16 @@
+<footer class="border-t border-zinc-800 mt-12">
+	<div class="max-w-4xl mx-auto px-6 py-8">
+		<div class="flex flex-wrap gap-6 justify-center text-sm text-zinc-400">
+			<a
+				href="https://github.com/Ishannaik/CloakBin"
+				target="_blank"
+				rel="noopener"
+				class="transition-colors hover:text-teal-400">GitHub</a
+			>
+			<a href="/.well-known/security.txt" class="transition-colors hover:text-teal-400">Security</a>
+		</div>
+		<p class="text-center text-xs text-zinc-500 mt-4">
+			© {new Date().getFullYear()} CloakBin. Zero-knowledge encrypted pastebin.
+		</p>
+	</div>
+</footer>

--- a/src/lib/utils/cipher-morph.ts
+++ b/src/lib/utils/cipher-morph.ts
@@ -1,0 +1,84 @@
+const CIPHER = '╬░▒▓█▐▌◆◇○●□■∀∂∃∅∇∈∋∏∑∞∧∨⊕⊗';
+const SCRAMBLE_MS = 2000;
+const FLICKER_FRAMES = 6;
+
+/** Fisher-Yates shuffle (in-place) */
+function shuffle<T>(arr: T[]): T[] {
+	for (let i = arr.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1));
+		[arr[i], arr[j]] = [arr[j], arr[i]];
+	}
+	return arr;
+}
+
+/**
+ * Morph text character-by-character from source → target.
+ * Calls `onFrame` each animation frame with the intermediate string.
+ * Returns a cleanup function to cancel the animation.
+ */
+export function startCipherMorph(
+	source: string,
+	target: string,
+	onFrame: (text: string) => void
+): () => void {
+	const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+	const original = source.split('');
+	const encrypted = target.split('');
+
+	if (original.length === 0 && encrypted.length === 0) {
+		onFrame(target);
+		return () => {};
+	}
+
+	const len = Math.max(original.length, encrypted.length);
+	while (original.length < len) original.push(' ');
+	while (encrypted.length < len) encrypted.push(' ');
+
+	if (reducedMotion) {
+		onFrame(target);
+		return () => {};
+	}
+
+	const indices = shuffle(Array.from({ length: len }, (_, i) => i));
+	const transitionRank = new Array(len);
+	indices.forEach((pos, rank) => {
+		transitionRank[pos] = rank;
+	});
+
+	onFrame(original.join(''));
+
+	const t0 = performance.now();
+	let rafId: number;
+
+	function tick(now: number) {
+		const progress = Math.min((now - t0) / SCRAMBLE_MS, 1);
+		const transitionedCount = Math.floor(progress * len);
+
+		const next: string[] = new Array(len);
+
+		for (let i = 0; i < len; i++) {
+			const rank = transitionRank[i];
+
+			if (rank < transitionedCount - FLICKER_FRAMES) {
+				next[i] = encrypted[i];
+			} else if (rank < transitionedCount) {
+				next[i] = CIPHER[Math.floor(Math.random() * CIPHER.length)];
+			} else {
+				next[i] = original[i];
+			}
+		}
+
+		onFrame(next.join(''));
+
+		if (progress >= 1) {
+			onFrame(target);
+			return;
+		}
+
+		rafId = requestAnimationFrame(tick);
+	}
+
+	rafId = requestAnimationFrame(tick);
+	return () => cancelAnimationFrame(rafId);
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,8 @@
 	import '../app.css';
 	import { page, navigating } from '$app/stores';
 	import MatrixRain from '$lib/components/MatrixRain.svelte';
+	import EncryptionBanner from '$lib/components/EncryptionBanner.svelte';
+	import Footer from '$lib/components/Footer.svelte';
 	import { jsonLd } from '$lib/utils/json-ld';
 
 	let { children } = $props();
@@ -162,9 +164,13 @@
 	</div>
 {/if}
 
+<!-- Zero-knowledge teaching banner -->
+<EncryptionBanner />
+
 <!-- Easter egg: "cloak" typing fades page to 10% opacity -->
 <div class="transition-opacity duration-500 {isCloaked ? 'opacity-10' : 'opacity-100'}">
 	{@render children()}
+	<Footer />
 </div>
 
 <style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
 	import logo from '$lib/assets/logo.svg';
 	import LazyCodeMirror from '$lib/components/LazyCodeMirror.svelte';
 	import ExpirySelect from '$lib/components/ExpirySelect.svelte';
+	import EncryptionOverlay from '$lib/components/EncryptionOverlay.svelte';
 	import { javascript } from '@codemirror/lang-javascript';
 	import { oneDark } from '@codemirror/theme-one-dark';
 	import { EditorView, keymap } from '@codemirror/view';
@@ -216,6 +217,7 @@
 		}
 	}
 	let isCreating = $state(false);
+	let encryptedPreview = $state(''); // ciphertext fed to the encrypt animation overlay
 
 	// Large paste loading state
 	let isLoadingPaste = $state(false);
@@ -422,6 +424,9 @@
 
 			// Encrypt content
 			const encrypted = await encrypt(content, key);
+			// Feed the ciphertext to the encrypt-animation overlay (morphs the editor content)
+			encryptedPreview = encrypted;
+			const morphStart = performance.now();
 
 			// POST to API
 			const res = await fetch('/api/paste', {
@@ -446,6 +451,11 @@
 
 			// Clear draft on successful create
 			localStorage.removeItem('cloakbin_draft');
+
+			// Let the encrypt animation play its full duration before navigating away
+			const MORPH_MS = 2000;
+			const remaining = MORPH_MS - (performance.now() - morphStart);
+			if (remaining > 0) await new Promise((r) => setTimeout(r, remaining));
 			content = ''; // Clear content so back button shows empty editor
 
 			// Redirect to view page
@@ -461,6 +471,7 @@
 			alert(error instanceof Error ? error.message : 'Failed to create paste. Please try again.');
 		} finally {
 			isCreating = false;
+			encryptedPreview = '';
 		}
 	}
 </script>
@@ -614,6 +625,13 @@
 				}
 			}}
 			placeholder="// Paste something private..."
+		/>
+		<!-- Encrypt animation: cipher-morph overlay while creating -->
+		<EncryptionOverlay
+			active={isCreating}
+			sourceText={content}
+			encryptedText={encryptedPreview}
+			onFrame={(text) => { content = text; }}
 		/>
 	</div>
 


### PR DESCRIPTION
Ports the EncryptionBanner (zero-knowledge teaching bar), the EncryptionOverlay cipher-morph encrypt animation (2s morph before navigate, wired into the create flow), and a trimmed Footer (GitHub + security.txt only — no content-page links) to match the hosted app. No premium bits. pnpm check 0 errors, build green.