### PR TITLE
Add cloakbin CLI — zero-knowledge terminal pastebin client

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,75 @@
+# cloakbin
+
+Zero-knowledge pastebin CLI. Content is encrypted on your machine with AES-256-GCM; the server only ever stores ciphertext. The decryption key lives in the URL fragment (`#…`) and is never sent to the server.
+
+## Install
+
+```bash
+npm i -g cloakbin
+# or, without installing:
+npx cloakbin
+```
+
+Requires Node.js 18+.
+
+## Usage
+
+```bash
+# encrypt a file and print a shareable URL
+cloakbin secret.txt
+
+# from stdin
+echo "hello" | cloakbin
+cloakbin - < secret.txt
+
+# password-protected (no key in the URL; recipient needs the password)
+cloakbin notes.md --password 's3cret'
+
+# burn after first browser view
+cloakbin leak.txt --burn --expiry 1h
+
+# syntax language hint
+cloakbin main.rs --lang rust
+
+# fetch & decrypt
+cloakbin get 'https://cloakbin.com/abc123#<key>'
+cloakbin get abc123 --host https://cloakbin.com   # needs #key in full URL form
+cloakbin get 'https://cloakbin.com/abc123' --password 's3cret'
+```
+
+Only the final URL (or decrypted plaintext for `get`) goes to stdout. Status and errors go to stderr.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-e, --expiry <1h\|24h\|7d\|30d\|1y>` | Paste lifetime (default: `7d`) |
+| `--burn` | Burn after first read in the browser |
+| `-p, --password <pw>` | Password mode (PBKDF2); no `#key` in URL |
+| `--lang <language>` | Language hint (`[a-zA-Z0-9_-]{1,30}`) |
+| `--host <url>` | API base URL (default: `https://cloakbin.com`) |
+| `-h, --help` | Show help |
+| `-v, --version` | Show version |
+
+## How the crypto works
+
+1. Plaintext is UTF-8 encoded, gzip-compressed (level 6), then encrypted with **AES-256-GCM** (random 12-byte IV).
+2. **Random-key mode** (default): a 32-byte key is generated with `crypto.getRandomValues`. The shareable URL is `https://host/<id>#<key>` where `<key>` is the raw key as base64url (no padding). The fragment is never transmitted to the server.
+3. **Password mode**: the key is derived with PBKDF2-SHA-256 (600 000 iterations) over a random 16-byte salt. The salt is stored with the paste; the URL has no fragment. Recipients must supply the password.
+4. Wire format (v1): magic bytes `CB` (`0x43 0x42`) + version `0x01` + IV (12) + ciphertext including the 16-byte GCM tag, then standard base64 for the API `content` field.
+
+Decryption reverses the pipeline and also accepts a legacy format (IV ‖ ciphertext, no gzip) for older pastes.
+
+## Self-hosting
+
+Point the client at your own instance:
+
+```bash
+cloakbin file.txt --host https://paste.example.com
+```
+
+Trailing slashes on `--host` are stripped. The API contract is `POST /api/paste` and `GET /api/paste/:id`.
+
+## License
+
+MIT

--- a/cli/bin/cloakbin.js
+++ b/cli/bin/cloakbin.js
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { encrypt, decrypt } from '../src/crypto.js';
+
+const VERSION = '0.1.0';
+const DEFAULT_HOST = 'https://cloakbin.com';
+const VALID_EXPIRY = new Set(['1h', '24h', '7d', '30d', '1y']);
+const LANG_RE = /^[a-zA-Z0-9_-]{1,30}$/;
+const UA = `cloakbin-cli/${VERSION}`;
+
+function usage() {
+  return `cloakbin — zero-knowledge encrypted pastebin CLI
+
+Usage:
+  cloakbin [file] [flags]          Encrypt and upload (file, -, or stdin)
+  cloakbin get <url-or-id> [flags] Fetch and decrypt a paste
+  cat file | cloakbin [flags]      Encrypt from pipe
+
+Flags:
+  -e, --expiry <1h|24h|7d|30d|1y>  Expiry (default: 7d)
+      --burn                       Burn after first browser read
+  -p, --password <pw>              Password-protect (no key in URL)
+      --lang <language>            Syntax language hint
+      --host <url>                 API host (default: https://cloakbin.com)
+  -h, --help                       Show help
+  -v, --version                    Show version
+`;
+}
+
+function fail(msg) {
+  process.stderr.write(`Error: ${msg}\n`);
+  process.exit(1);
+}
+
+/** Hand-rolled flag parser: supports --flag value and --flag=value */
+function parseArgs(argv) {
+  const flags = {
+    expiry: '7d',
+    burn: false,
+    password: null,
+    lang: null,
+    host: DEFAULT_HOST,
+    help: false,
+    version: false,
+  };
+  const positionals = [];
+  let i = 0;
+
+  while (i < argv.length) {
+    const arg = argv[i];
+
+    if (arg === '--') {
+      positionals.push(...argv.slice(i + 1));
+      break;
+    }
+
+    if (arg.startsWith('--')) {
+      const eq = arg.indexOf('=');
+      let name, value;
+      if (eq !== -1) {
+        name = arg.slice(2, eq);
+        value = arg.slice(eq + 1);
+      } else {
+        name = arg.slice(2);
+        value = undefined;
+      }
+
+      switch (name) {
+        case 'help':
+          flags.help = true;
+          break;
+        case 'version':
+          flags.version = true;
+          break;
+        case 'burn':
+          flags.burn = true;
+          break;
+        case 'expiry':
+          value = value !== undefined ? value : argv[++i];
+          if (value === undefined) fail('--expiry requires a value');
+          flags.expiry = value;
+          break;
+        case 'password':
+          value = value !== undefined ? value : argv[++i];
+          if (value === undefined) fail('--password requires a value');
+          flags.password = value;
+          break;
+        case 'lang':
+          value = value !== undefined ? value : argv[++i];
+          if (value === undefined) fail('--lang requires a value');
+          flags.lang = value;
+          break;
+        case 'host':
+          value = value !== undefined ? value : argv[++i];
+          if (value === undefined) fail('--host requires a value');
+          flags.host = value;
+          break;
+        default:
+          fail(`unknown flag --${name}`);
+      }
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith('-') && arg.length > 1 && arg !== '-') {
+      // short flags: -e, -p, -h, -v (possibly clustered not supported for valued)
+      const short = arg.slice(1);
+      if (short === 'h') {
+        flags.help = true;
+        i++;
+        continue;
+      }
+      if (short === 'v') {
+        flags.version = true;
+        i++;
+        continue;
+      }
+      if (short === 'e') {
+        const value = argv[++i];
+        if (value === undefined) fail('-e requires a value');
+        flags.expiry = value;
+        i++;
+        continue;
+      }
+      if (short === 'p') {
+        const value = argv[++i];
+        if (value === undefined) fail('-p requires a value');
+        flags.password = value;
+        i++;
+        continue;
+      }
+      // multi-char short like -e7d not supported; treat as unknown
+      fail(`unknown flag -${short}`);
+    }
+
+    positionals.push(arg);
+    i++;
+  }
+
+  // strip trailing slash from host
+  flags.host = flags.host.replace(/\/+$/, '');
+  return { flags, positionals };
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    process.stdin.on('data', (c) => chunks.push(c));
+    process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    process.stdin.on('error', reject);
+  });
+}
+
+async function readInput(positionals) {
+  // priority: file arg > `-` > piped stdin
+  const fileArg = positionals.find((p) => p !== 'get');
+  // when command is create, positionals are just the file (if any)
+  // caller passes only non-get positionals
+
+  if (fileArg && fileArg !== '-') {
+    try {
+      return readFileSync(fileArg, 'utf8');
+    } catch (err) {
+      fail(`cannot read file: ${fileArg} (${err.message})`);
+    }
+  }
+
+  if (fileArg === '-' || !process.stdin.isTTY) {
+    const data = await readStdin();
+    return data;
+  }
+
+  return null; // no input
+}
+
+async function createPaste(plaintext, flags) {
+  if (!VALID_EXPIRY.has(flags.expiry)) {
+    fail(`invalid expiry "${flags.expiry}" — must be one of: 1h, 24h, 7d, 30d, 1y`);
+  }
+  if (flags.lang != null && !LANG_RE.test(flags.lang)) {
+    fail(`invalid --lang "${flags.lang}" — use 1-30 chars: letters, digits, _ or -`);
+  }
+
+  const enc = await encrypt(plaintext, { password: flags.password || undefined });
+
+  const body = {
+    content: enc.contentBase64,
+    expiry: flags.expiry,
+  };
+  if (enc.saltBase64) body.salt = enc.saltBase64;
+  if (flags.burn) body.burnAfterRead = true;
+  if (flags.lang) body.language = flags.lang;
+
+  let res;
+  try {
+    res = await fetch(`${flags.host}/api/paste`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': UA,
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    fail(`network error: ${err.message}`);
+  }
+
+  if (res.status !== 201) {
+    let msg = `HTTP ${res.status}`;
+    try {
+      const j = await res.json();
+      if (j && j.error) msg = j.error;
+    } catch {
+      /* ignore */
+    }
+    fail(msg);
+  }
+
+  let data;
+  try {
+    data = await res.json();
+  } catch {
+    fail('invalid JSON in create response');
+  }
+  if (!data.id) fail('server response missing id');
+
+  let url = `${flags.host}/${data.id}`;
+  if (enc.keyBase64url) {
+    url += `#${enc.keyBase64url}`;
+  }
+
+  process.stderr.write('🔒 Encrypted locally — server only received ciphertext\n');
+  if (flags.password) {
+    process.stderr.write('Password mode: recipient must supply the password to decrypt.\n');
+  }
+  process.stdout.write(url + '\n');
+}
+
+function parsePasteRef(ref, defaultHost) {
+  // full URL or bare id
+  let id;
+  let keyBase64url = null;
+  let host = defaultHost;
+
+  if (ref.includes('://') || ref.startsWith('//')) {
+    let u;
+    try {
+      u = new URL(ref);
+    } catch {
+      fail(`invalid URL: ${ref}`);
+    }
+    host = `${u.protocol}//${u.host}`;
+    // pathname like /id or /id/
+    id = u.pathname.replace(/^\/+|\/+$/g, '').split('/')[0];
+    if (u.hash && u.hash.length > 1) {
+      keyBase64url = decodeURIComponent(u.hash.slice(1));
+    }
+  } else if (ref.includes('#')) {
+    // id#key without scheme
+    const idx = ref.indexOf('#');
+    id = ref.slice(0, idx);
+    keyBase64url = decodeURIComponent(ref.slice(idx + 1));
+  } else {
+    id = ref;
+  }
+
+  if (!id) fail('missing paste id');
+  return { id, keyBase64url, host };
+}
+
+async function getPaste(ref, flags) {
+  const { id, keyBase64url, host } = parsePasteRef(ref, flags.host);
+
+  let res;
+  try {
+    res = await fetch(`${host}/api/paste/${encodeURIComponent(id)}`, {
+      method: 'GET',
+      headers: { 'User-Agent': UA },
+    });
+  } catch (err) {
+    fail(`network error: ${err.message}`);
+  }
+
+  if (res.status === 404) {
+    fail('paste not found or expired');
+  }
+  if (res.status !== 200) {
+    let msg = `HTTP ${res.status}`;
+    try {
+      const j = await res.json();
+      if (j && j.error) msg = j.error;
+    } catch {
+      /* ignore */
+    }
+    fail(msg);
+  }
+
+  let data;
+  try {
+    data = await res.json();
+  } catch {
+    fail('invalid JSON in get response');
+  }
+
+  if (data.burnAfterRead) {
+    process.stderr.write(
+      'Warning: this paste is burn-after-read; viewing it in a browser would destroy it. API GET does not auto-burn.\n'
+    );
+  }
+
+  const hasPassword = !!data.hasPassword;
+  if (hasPassword && !flags.password) {
+    fail('this paste is password-protected; provide --password');
+  }
+  if (!hasPassword && !keyBase64url) {
+    fail('missing #key in URL');
+  }
+
+  let plaintext;
+  try {
+    if (hasPassword) {
+      plaintext = await decrypt(data.content, {
+        password: flags.password,
+        saltBase64: data.salt,
+      });
+    } else {
+      plaintext = await decrypt(data.content, { keyBase64url });
+    }
+  } catch (err) {
+    fail(err.message);
+  }
+
+  // print plaintext exactly — no extra trailing newline beyond content
+  process.stdout.write(plaintext);
+}
+
+async function main() {
+  const { flags, positionals } = parseArgs(process.argv.slice(2));
+
+  if (flags.help) {
+    process.stdout.write(usage());
+    process.exit(0);
+  }
+  if (flags.version) {
+    process.stdout.write(`cloakbin ${VERSION}\n`);
+    process.exit(0);
+  }
+
+  if (positionals[0] === 'get') {
+    const ref = positionals[1];
+    if (!ref) fail('usage: cloakbin get <url-or-id>');
+    await getPaste(ref, flags);
+    return;
+  }
+
+  // create mode
+  const input = await readInput(positionals);
+  if (input === null) {
+    process.stderr.write(usage());
+    process.exit(1);
+  }
+  if (input === '') {
+    fail('no input');
+  }
+
+  await createPaste(input, flags);
+}
+
+main().catch((err) => {
+  fail(err.message || String(err));
+});

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "cloakbin",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cloakbin",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      },
+      "bin": {
+        "cloakbin": "bin/cloakbin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    }
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "cloakbin",
+  "version": "0.1.0",
+  "description": "Zero-knowledge encrypted pastebin CLI — content is encrypted on your machine before upload",
+  "type": "module",
+  "bin": {
+    "cloakbin": "./bin/cloakbin.js"
+  },
+  "files": [
+    "bin",
+    "src",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "test": "node test/roundtrip.test.js"
+  },
+  "dependencies": {
+    "fflate": "^0.8.2"
+  },
+  "license": "MIT",
+  "author": "Ishan Naik",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Ishannaik/CloakBin.git",
+    "directory": "cli"
+  },
+  "keywords": [
+    "pastebin",
+    "encryption",
+    "aes-gcm",
+    "zero-knowledge",
+    "cli"
+  ]
+}

--- a/cli/src/crypto.js
+++ b/cli/src/crypto.js
@@ -1,0 +1,186 @@
+/**
+ * CloakBin crypto — AES-256-GCM with optional PBKDF2 password derivation.
+ *
+ * Combined ciphertext format (v1):
+ *   [0x43, 0x42]  "CB" magic
+ *   [0x01]        version
+ *   IV (12 bytes)
+ *   ciphertext + GCM tag (16 bytes appended by WebCrypto)
+ *
+ * Legacy (no magic): IV(12) || ciphertext+tag, plaintext not gzipped.
+ */
+
+import { gzipSync, gunzipSync } from 'fflate';
+
+const MAGIC = new Uint8Array([0x43, 0x42]); // "CB"
+const VERSION = 0x01;
+const IV_LEN = 12;
+const SALT_LEN = 16;
+const KEY_LEN = 32;
+const PBKDF2_ITERATIONS = 600000;
+
+function getCrypto() {
+  return globalThis.crypto;
+}
+
+/** raw bytes -> standard base64 (with padding) */
+export function toBase64(bytes) {
+  return Buffer.from(bytes).toString('base64');
+}
+
+/** standard base64 -> Uint8Array */
+export function fromBase64(str) {
+  return new Uint8Array(Buffer.from(str, 'base64'));
+}
+
+/** raw 32-byte key -> base64url (no padding, +→-, /→_) */
+export function keyToBase64url(keyBytes) {
+  return toBase64(keyBytes).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** base64url -> raw key bytes */
+export function keyFromBase64url(str) {
+  let b64 = str.replace(/-/g, '+').replace(/_/g, '/');
+  while (b64.length % 4 !== 0) b64 += '=';
+  return fromBase64(b64);
+}
+
+async function importAesKey(rawKeyBytes) {
+  return getCrypto().subtle.importKey(
+    'raw',
+    rawKeyBytes,
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt']
+  );
+}
+
+/**
+ * Derive AES-GCM key from password via PBKDF2-SHA256 (600k iterations).
+ * saltBytes: 16 random bytes
+ */
+export async function deriveKeyFromPassword(password, saltBytes) {
+  const crypto = getCrypto();
+  const pwKey = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(password),
+    'PBKDF2',
+    false,
+    ['deriveBits', 'deriveKey']
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: saltBytes,
+      iterations: PBKDF2_ITERATIONS,
+      hash: 'SHA-256',
+    },
+    pwKey,
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt']
+  );
+}
+
+/**
+ * Encrypt plaintext string.
+ * Returns { contentBase64, keyBase64url?, saltBase64? }
+ * - Random-key mode: keyBase64url set, no salt
+ * - Password mode: pass password string; saltBase64 set, no keyBase64url
+ */
+export async function encrypt(plaintext, { password } = {}) {
+  const crypto = getCrypto();
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LEN));
+
+  let key;
+  let keyBytes = null;
+  let saltBase64 = null;
+
+  if (password != null && password !== '') {
+    const saltBytes = crypto.getRandomValues(new Uint8Array(SALT_LEN));
+    saltBase64 = toBase64(saltBytes);
+    key = await deriveKeyFromPassword(password, saltBytes);
+  } else {
+    keyBytes = crypto.getRandomValues(new Uint8Array(KEY_LEN));
+    key = await importAesKey(keyBytes);
+  }
+
+  // plaintext -> UTF-8 -> gzip level 6 -> AES-GCM
+  const plainBytes = new TextEncoder().encode(plaintext);
+  const compressed = gzipSync(plainBytes, { level: 6 });
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, compressed)
+  );
+
+  // combined = magic(2) + version(1) + IV(12) + ciphertext+tag
+  const combined = new Uint8Array(2 + 1 + IV_LEN + ciphertext.length);
+  combined[0] = MAGIC[0];
+  combined[1] = MAGIC[1];
+  combined[2] = VERSION;
+  combined.set(iv, 3);
+  combined.set(ciphertext, 3 + IV_LEN);
+
+  const result = { contentBase64: toBase64(combined) };
+  if (keyBytes) result.keyBase64url = keyToBase64url(keyBytes);
+  if (saltBase64) result.saltBase64 = saltBase64;
+  return result;
+}
+
+/**
+ * Decrypt contentBase64 from server.
+ * opts: { keyBase64url } for random-key mode, or { password, saltBase64 } for password mode.
+ */
+export async function decrypt(contentBase64, opts = {}) {
+  const crypto = getCrypto();
+  const combined = fromBase64(contentBase64);
+
+  let iv;
+  let ciphertext;
+  let isNewFormat = false;
+
+  // New format: magic "CB" + version 0x01
+  if (
+    combined.length >= 3 + IV_LEN &&
+    combined[0] === MAGIC[0] &&
+    combined[1] === MAGIC[1] &&
+    combined[2] === VERSION
+  ) {
+    isNewFormat = true;
+    iv = combined.subarray(3, 3 + IV_LEN);
+    ciphertext = combined.subarray(3 + IV_LEN);
+  } else {
+    // Legacy: IV(12) || ciphertext+tag, no gzip
+    if (combined.length < IV_LEN) {
+      throw new Error('ciphertext too short');
+    }
+    iv = combined.subarray(0, IV_LEN);
+    ciphertext = combined.subarray(IV_LEN);
+  }
+
+  let key;
+  if (opts.password != null && opts.password !== '') {
+    if (!opts.saltBase64) throw new Error('password mode requires salt');
+    const saltBytes = fromBase64(opts.saltBase64);
+    key = await deriveKeyFromPassword(opts.password, saltBytes);
+  } else if (opts.keyBase64url) {
+    const keyBytes = keyFromBase64url(opts.keyBase64url);
+    key = await importAesKey(keyBytes);
+  } else {
+    throw new Error('missing decryption key or password');
+  }
+
+  let plainBytes;
+  try {
+    plainBytes = new Uint8Array(
+      await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext)
+    );
+  } catch {
+    throw new Error('decryption failed — wrong key/password or corrupted data');
+  }
+
+  if (isNewFormat) {
+    plainBytes = gunzipSync(plainBytes);
+  }
+
+  return new TextDecoder().decode(plainBytes);
+}

--- a/cli/test/roundtrip.test.js
+++ b/cli/test/roundtrip.test.js
@@ -1,0 +1,161 @@
+/**
+ * Offline round-trip tests — no network.
+ * Run: node test/roundtrip.test.js
+ */
+
+import assert from 'node:assert/strict';
+import {
+  encrypt,
+  decrypt,
+  keyToBase64url,
+  keyFromBase64url,
+  toBase64,
+  fromBase64,
+} from '../src/crypto.js';
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => {
+      passed++;
+      console.log(`  ok  ${name}`);
+    })
+    .catch((err) => {
+      failed++;
+      console.error(`  FAIL ${name}`);
+      console.error(`       ${err.message}`);
+      if (err.stack) console.error(err.stack.split('\n').slice(1, 3).join('\n'));
+    });
+}
+
+async function run() {
+  console.log('cloakbin round-trip tests\n');
+
+  await test('key base64url encode/decode round-trip', () => {
+    const raw = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) raw[i] = i * 7 + 3;
+    const encoded = keyToBase64url(raw);
+    assert.ok(!encoded.includes('+'), 'no +');
+    assert.ok(!encoded.includes('/'), 'no /');
+    assert.ok(!encoded.includes('='), 'no padding');
+    const decoded = keyFromBase64url(encoded);
+    assert.equal(decoded.length, 32);
+    assert.deepEqual(decoded, raw);
+  });
+
+  await test('key base64url handles +/ characters', () => {
+    // craft bytes that produce + and / in standard base64
+    const raw = fromBase64('+/+/+/+/+/+/+/+/+/+/+/+/+/+/+/+/+/+/+/+/+/+/=');
+    // ensure we have 32 bytes-ish — pad/slice
+    const key = new Uint8Array(32);
+    key.set(raw.subarray(0, Math.min(32, raw.length)));
+    const encoded = keyToBase64url(key);
+    assert.ok(!/[+/=]/.test(encoded));
+    const back = keyFromBase64url(encoded);
+    assert.deepEqual(back, key);
+  });
+
+  await test('random-key encrypt → decrypt equality', async () => {
+    const plain = 'Hello, CloakBin! 🔐\nLine two.\n';
+    const { contentBase64, keyBase64url, saltBase64 } = await encrypt(plain);
+    assert.ok(contentBase64, 'content present');
+    assert.ok(keyBase64url, 'key present');
+    assert.equal(saltBase64, undefined, 'no salt in random-key mode');
+    const out = await decrypt(contentBase64, { keyBase64url });
+    assert.equal(out, plain);
+  });
+
+  await test('random-key empty-ish and unicode', async () => {
+    const plain = 'αβγ 日本語 emoji 🎉 zero\u0000byte';
+    const { contentBase64, keyBase64url } = await encrypt(plain);
+    const out = await decrypt(contentBase64, { keyBase64url });
+    assert.equal(out, plain);
+  });
+
+  await test('password mode encrypt → decrypt equality', async () => {
+    const plain = 'secret password-protected payload';
+    const password = 'correct horse battery staple';
+    const { contentBase64, keyBase64url, saltBase64 } = await encrypt(plain, { password });
+    assert.ok(contentBase64);
+    assert.equal(keyBase64url, undefined, 'no key fragment in password mode');
+    assert.ok(saltBase64, 'salt present');
+    // salt is standard base64
+    assert.ok(/^[A-Za-z0-9+/]+=*$/.test(saltBase64));
+    const out = await decrypt(contentBase64, { password, saltBase64 });
+    assert.equal(out, plain);
+  });
+
+  await test('password mode wrong password fails', async () => {
+    const { contentBase64, saltBase64 } = await encrypt('x', { password: 'right' });
+    await assert.rejects(
+      () => decrypt(contentBase64, { password: 'wrong', saltBase64 }),
+      /decrypt/i
+    );
+  });
+
+  await test('combined format byte layout (magic/version/IV)', async () => {
+    const plain = 'layout-check';
+    const { contentBase64 } = await encrypt(plain);
+    const combined = fromBase64(contentBase64);
+
+    // magic "CB"
+    assert.equal(combined[0], 0x43, 'magic[0] = C');
+    assert.equal(combined[1], 0x42, 'magic[1] = B');
+    // version
+    assert.equal(combined[2], 0x01, 'version = 0x01');
+    // IV is 12 bytes at offset 3; ciphertext+tag follows (at least 16 tag bytes)
+    assert.ok(combined.length >= 3 + 12 + 16, 'min length magic+ver+iv+tag');
+    // IV region should not be all zeros (extremely unlikely with CSPRNG)
+    const iv = combined.subarray(3, 15);
+    const allZero = iv.every((b) => b === 0);
+    assert.ok(!allZero, 'IV should be random non-zero');
+    // content field is STANDARD base64 (may contain +, /, =)
+    assert.ok(/^[A-Za-z0-9+/]+=*$/.test(contentBase64), 'standard base64');
+  });
+
+  await test('legacy format decrypt (no magic, no gunzip)', async () => {
+    // Build legacy: IV(12) || AES-GCM(plaintext)  — plaintext NOT gzipped
+    const crypto = globalThis.crypto;
+    const keyBytes = crypto.getRandomValues(new Uint8Array(32));
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const key = await crypto.subtle.importKey(
+      'raw',
+      keyBytes,
+      { name: 'AES-GCM', length: 256 },
+      true,
+      ['encrypt', 'decrypt']
+    );
+    const plain = 'legacy plaintext';
+    const plainBytes = new TextEncoder().encode(plain);
+    const ct = new Uint8Array(
+      await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plainBytes)
+    );
+    const combined = new Uint8Array(12 + ct.length);
+    combined.set(iv, 0);
+    combined.set(ct, 12);
+    const contentBase64 = toBase64(combined);
+    const keyBase64url = keyToBase64url(keyBytes);
+
+    // must NOT look like new format
+    assert.ok(!(combined[0] === 0x43 && combined[1] === 0x42 && combined[2] === 0x01));
+
+    const out = await decrypt(contentBase64, { keyBase64url });
+    assert.equal(out, plain);
+  });
+
+  await test('toBase64 / fromBase64 round-trip', () => {
+    const bytes = new Uint8Array([0, 1, 2, 255, 128, 64]);
+    assert.deepEqual(fromBase64(toBase64(bytes)), bytes);
+  });
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## `cloakbin` CLI

A free, dependency-light command-line client for CloakBin. Encrypts content **locally** (AES-256-GCM + gzip, byte-for-byte matching the web app's format) and uploads **only ciphertext** — the key stays in the URL fragment and never touches the network.

```bash
cat secrets.env | cloakbin            # -> https://cloakbin.com/<id>#<key>
cloakbin notes.txt --expiry 24h --burn
echo "secret" | cloakbin --password hunter2
cloakbin log.txt --host https://my-selfhosted-instance.com
```

**Flags:** `--expiry` (1h/24h/7d/30d/1y) · `--burn` · `--password` · `--lang` · `--host` · `--help` · `--version`

- Hits the **free anonymous** `/api/paste` endpoint (no account needed).
- Single runtime dependency (`fflate`); everything else uses Node's built-in WebCrypto/fetch. Node ≥18.
- `--host` lets self-hosters point at their own instance.

### Verified
- 9/9 round-trip unit tests pass (random-key + password modes, format byte layout, legacy fallback).
- **Interop confirmed end-to-end:** a CLI-created link opened in a real browser decrypts correctly on cloakbin.com (Playwright).

Location: `cli/` (own package.json, publish-ready as `npx cloakbin` once published).