### PR TITLE
feat(cli): human expiry durations + file-extension language auto-detect

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -18,6 +18,11 @@ Requires Node.js 18+.
 # encrypt a file and print a shareable URL
 cloakbin secret.txt
 
+# language is auto-detected from the file extension (override with --lang)
+cloakbin script.py --expiry 3d
+# → stderr: language python (from .py); expiry 3d snapped up to 7d
+# → stdout: https://cloakbin.com/<id>#<key>
+
 # from stdin
 echo "hello" | cloakbin
 cloakbin - < secret.txt
@@ -28,7 +33,11 @@ cloakbin notes.md --password 's3cret'
 # burn after first browser view
 cloakbin leak.txt --burn --expiry 1h
 
-# syntax language hint
+# human-friendly durations (snapped up to free-tier buckets)
+cloakbin notes.txt --expiry 2h30m   # → applied 24h
+cloakbin notes.txt --expiry 1w2d    # → applied 30d
+
+# syntax language hint (overrides auto-detect)
 cloakbin main.rs --lang rust
 
 # fetch & decrypt
@@ -39,14 +48,16 @@ cloakbin get 'https://cloakbin.com/abc123' --password 's3cret'
 
 Only the final URL (or decrypted plaintext for `get`) goes to stdout. Status and errors go to stderr.
 
+When uploading a real file (not stdin/`-`), the CLI auto-detects a syntax language from the extension (e.g. `.py` → `python`, `Dockerfile` → `dockerfile`). Pass `--lang` to override; stdin input sends no language unless `--lang` is set.
+
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `-e, --expiry <1h\|24h\|7d\|30d\|1y>` | Paste lifetime (default: `7d`) |
+| `-e, --expiry <bucket\|duration>` | Paste lifetime (default: `7d`). Exact free-tier buckets: `1h`, `24h`, `7d`, `30d`, `1y`. Or a human duration like `2h30m`, `3d`, `1w2d`, `45m` (units `w`/`d`/`h`/`m`, each at most once, any order). Durations snap **up** to the smallest bucket that fits; values over 1 year cap at `1y`. Exact custom expiry is a premium feature. |
 | `--burn` | Burn after first read in the browser |
 | `-p, --password <pw>` | Password mode (PBKDF2); no `#key` in URL |
-| `--lang <language>` | Language hint (`[a-zA-Z0-9_-]{1,30}`) |
+| `--lang <language>` | Language hint (`[a-zA-Z0-9_-]{1,30}`); auto-detected from file extension when omitted |
 | `--host <url>` | API base URL (default: `https://cloakbin.com`) |
 | `-h, --help` | Show help |
 | `-v, --version` | Show version |

--- a/cli/bin/cloakbin.js
+++ b/cli/bin/cloakbin.js
@@ -2,10 +2,11 @@
 
 import { readFileSync } from 'node:fs';
 import { encrypt, decrypt } from '../src/crypto.js';
+import { detectLanguage } from '../src/lang-detect.js';
+import { resolveExpiry } from '../src/duration.js';
 
 const VERSION = '0.1.0';
 const DEFAULT_HOST = 'https://cloakbin.com';
-const VALID_EXPIRY = new Set(['1h', '24h', '7d', '30d', '1y']);
 const LANG_RE = /^[a-zA-Z0-9_-]{1,30}$/;
 const UA = `cloakbin-cli/${VERSION}`;
 
@@ -18,10 +19,10 @@ Usage:
   cat file | cloakbin [flags]      Encrypt from pipe
 
 Flags:
-  -e, --expiry <1h|24h|7d|30d|1y>  Expiry (default: 7d)
+  -e, --expiry <bucket|duration>   Expiry: 1h|24h|7d|30d|1y or e.g. 2h30m, 3d (default: 7d)
       --burn                       Burn after first browser read
   -p, --password <pw>              Password-protect (no key in URL)
-      --lang <language>            Syntax language hint
+      --lang <language>            Syntax language hint (auto-detected from file ext)
       --host <url>                 API host (default: https://cloakbin.com)
   -h, --help                       Show help
   -v, --version                    Show version
@@ -152,6 +153,10 @@ function readStdin() {
   });
 }
 
+/**
+ * @returns {Promise<{ content: string, filename: string|null } | null>}
+ * filename is set only when input came from a real file argument (not `-` / stdin).
+ */
 async function readInput(positionals) {
   // priority: file arg > `-` > piped stdin
   const fileArg = positionals.find((p) => p !== 'get');
@@ -160,7 +165,8 @@ async function readInput(positionals) {
 
   if (fileArg && fileArg !== '-') {
     try {
-      return readFileSync(fileArg, 'utf8');
+      const content = readFileSync(fileArg, 'utf8');
+      return { content, filename: fileArg };
     } catch (err) {
       fail(`cannot read file: ${fileArg} (${err.message})`);
     }
@@ -168,16 +174,26 @@ async function readInput(positionals) {
 
   if (fileArg === '-' || !process.stdin.isTTY) {
     const data = await readStdin();
-    return data;
+    return { content: data, filename: null };
   }
 
   return null; // no input
 }
 
 async function createPaste(plaintext, flags) {
-  if (!VALID_EXPIRY.has(flags.expiry)) {
-    fail(`invalid expiry "${flags.expiry}" — must be one of: 1h, 24h, 7d, 30d, 1y`);
+  const resolved = resolveExpiry(flags.expiry);
+  if (!resolved) {
+    fail(
+      `invalid expiry "${flags.expiry}" — use 1h|24h|7d|30d|1y or a duration like 2h30m, 3d, 1w2d`
+    );
   }
+  if (resolved.snapped || resolved.capped) {
+    process.stderr.write(
+      `⏳ expiry ${flags.expiry} → applied ${resolved.bucket} (free tier uses fixed buckets; exact expiry is a premium feature)\n`
+    );
+  }
+  flags.expiry = resolved.bucket;
+
   if (flags.lang != null && !LANG_RE.test(flags.lang)) {
     fail(`invalid --lang "${flags.lang}" — use 1-30 chars: letters, digits, _ or -`);
   }
@@ -360,11 +376,23 @@ async function main() {
     process.stderr.write(usage());
     process.exit(1);
   }
-  if (input === '') {
+  if (input.content === '') {
     fail('no input');
   }
 
-  await createPaste(input, flags);
+  // auto-detect language from real file when --lang not given
+  if (flags.lang == null && input.filename) {
+    const detected = detectLanguage(input.filename);
+    if (detected != null && LANG_RE.test(detected)) {
+      flags.lang = detected;
+      const ext = input.filename.includes('.')
+        ? input.filename.slice(input.filename.lastIndexOf('.'))
+        : input.filename;
+      process.stderr.write(`🎨 language: ${detected} (auto-detected from ${ext})\n`);
+    }
+  }
+
+  await createPaste(input.content, flags);
 }
 
 main().catch((err) => {

--- a/cli/package.json
+++ b/cli/package.json
@@ -15,7 +15,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "node test/roundtrip.test.js"
+    "test": "node test/roundtrip.test.js && node test/units.test.js"
   },
   "dependencies": {
     "fflate": "^0.8.2"

--- a/cli/src/duration.js
+++ b/cli/src/duration.js
@@ -1,0 +1,88 @@
+const MS = {
+  w: 7 * 24 * 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+  h: 60 * 60 * 1000,
+  m: 60 * 1000,
+};
+
+const BUCKETS = [
+  { name: '1h', ms: 3_600_000 },
+  { name: '24h', ms: 86_400_000 },
+  { name: '7d', ms: 604_800_000 },
+  { name: '30d', ms: 2_592_000_000 },
+  { name: '1y', ms: 31_536_000_000 },
+];
+
+const EXACT_BUCKETS = new Set(BUCKETS.map((b) => b.name));
+
+/**
+ * Parse a human duration like `2h30m`, `1w2d`, `45m`.
+ * Units w/d/h/m, each at most once, any order, case-insensitive.
+ * @param {string} str
+ * @returns {number|null} total milliseconds > 0, or null
+ */
+export function parseDuration(str) {
+  if (str == null || typeof str !== 'string' || str === '') return null;
+
+  // whole-string: one or more (\d+[wdhm]), each unit at most once
+  if (!/^(\d+[wdhm])+$/i.test(str)) return null;
+
+  const re = /(\d+)([wdhm])/gi;
+  const seen = new Set();
+  let total = 0;
+  let m;
+  while ((m = re.exec(str)) !== null) {
+    const unit = m[2].toLowerCase();
+    if (seen.has(unit)) return null; // unit repeated
+    seen.add(unit);
+    const n = Number(m[1]);
+    if (!Number.isFinite(n) || n < 0) return null;
+    total += n * MS[unit];
+  }
+
+  if (total <= 0) return null;
+  return total;
+}
+
+/**
+ * Resolve expiry string to a free-tier bucket.
+ * @param {string} str
+ * @returns {{ bucket: string, requestedMs: number, snapped: boolean, capped: boolean } | null}
+ */
+export function resolveExpiry(str) {
+  if (str == null || typeof str !== 'string' || str === '') return null;
+
+  if (EXACT_BUCKETS.has(str)) {
+    const b = BUCKETS.find((x) => x.name === str);
+    return {
+      bucket: str,
+      requestedMs: b.ms,
+      snapped: false,
+      capped: false,
+    };
+  }
+
+  const requestedMs = parseDuration(str);
+  if (requestedMs == null) return null;
+
+  const max = BUCKETS[BUCKETS.length - 1];
+  if (requestedMs > max.ms) {
+    return {
+      bucket: max.name,
+      requestedMs,
+      snapped: true,
+      capped: true,
+    };
+  }
+
+  const bucket = BUCKETS.find((b) => b.ms >= requestedMs);
+  // always found since requestedMs <= max.ms
+  return {
+    bucket: bucket.name,
+    requestedMs,
+    snapped: bucket.ms !== requestedMs,
+    capped: false,
+  };
+}
+
+export { BUCKETS, EXACT_BUCKETS };

--- a/cli/src/lang-detect.js
+++ b/cli/src/lang-detect.js
@@ -1,0 +1,106 @@
+/** Map file extension (lowercase, no dot) or bare name → language id */
+
+const EXT_MAP = {
+  py: 'python',
+  js: 'javascript',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  ts: 'typescript',
+  mts: 'typescript',
+  cts: 'typescript',
+  tsx: 'tsx',
+  jsx: 'jsx',
+  go: 'go',
+  rs: 'rust',
+  rb: 'ruby',
+  java: 'java',
+  c: 'c',
+  h: 'c',
+  cpp: 'cpp',
+  cc: 'cpp',
+  cxx: 'cpp',
+  hpp: 'cpp',
+  cs: 'csharp',
+  php: 'php',
+  swift: 'swift',
+  kt: 'kotlin',
+  kts: 'kotlin',
+  md: 'markdown',
+  markdown: 'markdown',
+  json: 'json',
+  yml: 'yaml',
+  yaml: 'yaml',
+  toml: 'toml',
+  xml: 'xml',
+  html: 'html',
+  htm: 'html',
+  css: 'css',
+  scss: 'scss',
+  sh: 'bash',
+  bash: 'bash',
+  zsh: 'bash',
+  sql: 'sql',
+  txt: 'plaintext',
+  lua: 'lua',
+  pl: 'perl',
+  r: 'r',
+  dart: 'dart',
+  scala: 'scala',
+  hs: 'haskell',
+  ex: 'elixir',
+  exs: 'elixir',
+  erl: 'erlang',
+  clj: 'clojure',
+  vue: 'vue',
+  svelte: 'svelte',
+  ini: 'ini',
+  ps1: 'powershell',
+  bat: 'batch',
+  cmd: 'batch',
+  diff: 'diff',
+  patch: 'diff',
+  tex: 'latex',
+  zig: 'zig',
+  nim: 'nim',
+  proto: 'protobuf',
+  graphql: 'graphql',
+  gql: 'graphql',
+  tf: 'hcl',
+  env: 'bash',
+  dockerfile: 'dockerfile',
+};
+
+const BARE_NAMES = {
+  dockerfile: 'dockerfile',
+  makefile: 'makefile',
+};
+
+/**
+ * Detect language from a filename by extension (or bare Dockerfile/Makefile).
+ * @param {string} filename
+ * @returns {string|null} lowercase language id, or null
+ */
+export function detectLanguage(filename) {
+  if (!filename || typeof filename !== 'string') return null;
+
+  // basename only
+  const base = filename.replace(/\\/g, '/').split('/').pop();
+  if (!base) return null;
+
+  const lower = base.toLowerCase();
+
+  // bare names without extension
+  if (BARE_NAMES[lower]) return BARE_NAMES[lower];
+
+  const dot = lower.lastIndexOf('.');
+  if (dot === -1 || dot === lower.length - 1) return null;
+
+  // handle leading-dot files like .env → ext "env"
+  const ext = lower.slice(dot + 1);
+  if (!ext) return null;
+
+  return EXT_MAP[ext] ?? null;
+}
+
+/** Exported for tests — every value must match LANG_RE */
+export const LANGUAGE_MAP = { ...EXT_MAP, ...BARE_NAMES };

--- a/cli/test/units.test.js
+++ b/cli/test/units.test.js
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for lang-detect and duration — no network.
+ * Run: node test/units.test.js
+ */
+
+import assert from 'node:assert/strict';
+import { detectLanguage, LANGUAGE_MAP } from '../src/lang-detect.js';
+import { parseDuration, resolveExpiry } from '../src/duration.js';
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => {
+      passed++;
+      console.log(`  ok  ${name}`);
+    })
+    .catch((err) => {
+      failed++;
+      console.error(`  FAIL ${name}`);
+      console.error(`       ${err.message}`);
+      if (err.stack) console.error(err.stack.split('\n').slice(1, 3).join('\n'));
+    });
+}
+
+const LANG_RE = /^[a-zA-Z0-9_-]{1,30}$/;
+
+async function run() {
+  console.log('cloakbin unit tests\n');
+
+  // --- detectLanguage ---
+  await test('detectLanguage .py → python', () => {
+    assert.equal(detectLanguage('script.py'), 'python');
+    assert.equal(detectLanguage('/path/to/foo.py'), 'python');
+  });
+
+  await test('detectLanguage .ts → typescript', () => {
+    assert.equal(detectLanguage('app.ts'), 'typescript');
+  });
+
+  await test('detectLanguage .tsx → tsx', () => {
+    assert.equal(detectLanguage('Component.tsx'), 'tsx');
+  });
+
+  await test('detectLanguage .yml → yaml', () => {
+    assert.equal(detectLanguage('config.yml'), 'yaml');
+  });
+
+  await test('detectLanguage Dockerfile → dockerfile', () => {
+    assert.equal(detectLanguage('Dockerfile'), 'dockerfile');
+    assert.equal(detectLanguage('dockerfile'), 'dockerfile');
+    assert.equal(detectLanguage('image.dockerfile'), 'dockerfile');
+  });
+
+  await test('detectLanguage .SH uppercase → bash', () => {
+    assert.equal(detectLanguage('setup.SH'), 'bash');
+  });
+
+  await test('detectLanguage unknown ext → null', () => {
+    assert.equal(detectLanguage('file.xyzzy'), null);
+  });
+
+  await test('detectLanguage no ext → null', () => {
+    assert.equal(detectLanguage('README'), null);
+    assert.equal(detectLanguage('Makefile'), 'makefile'); // bare name exception
+  });
+
+  await test('detectLanguage all map values match LANG_RE', () => {
+    for (const [key, val] of Object.entries(LANGUAGE_MAP)) {
+      assert.ok(LANG_RE.test(val), `value for ${key}="${val}" must match LANG_RE`);
+    }
+  });
+
+  // --- parseDuration ---
+  await test('parseDuration 45m → 2_700_000', () => {
+    assert.equal(parseDuration('45m'), 2_700_000);
+  });
+
+  await test('parseDuration 1h → 3_600_000', () => {
+    assert.equal(parseDuration('1h'), 3_600_000);
+  });
+
+  await test('parseDuration 2h30m → 9_000_000', () => {
+    assert.equal(parseDuration('2h30m'), 9_000_000);
+  });
+
+  await test('parseDuration 1w2d → 777_600_000', () => {
+    assert.equal(parseDuration('1w2d'), 777_600_000);
+  });
+
+  await test('parseDuration 90m → 5_400_000', () => {
+    assert.equal(parseDuration('90m'), 5_400_000);
+  });
+
+  await test('parseDuration case-insensitive 2H30M', () => {
+    assert.equal(parseDuration('2H30M'), 9_000_000);
+  });
+
+  await test('parseDuration invalid cases', () => {
+    assert.equal(parseDuration(''), null);
+    assert.equal(parseDuration('abc'), null);
+    assert.equal(parseDuration('5'), null);
+    assert.equal(parseDuration('1s'), null);
+    assert.equal(parseDuration('2y'), null);
+    assert.equal(parseDuration('0m'), null);
+  });
+
+  // --- resolveExpiry ---
+  await test('resolveExpiry exact 24h unsnapped', () => {
+    const r = resolveExpiry('24h');
+    assert.ok(r);
+    assert.equal(r.bucket, '24h');
+    assert.equal(r.snapped, false);
+    assert.equal(r.capped, false);
+  });
+
+  await test('resolveExpiry exact 1y unsnapped', () => {
+    const r = resolveExpiry('1y');
+    assert.ok(r);
+    assert.equal(r.bucket, '1y');
+    assert.equal(r.snapped, false);
+    assert.equal(r.capped, false);
+  });
+
+  await test('resolveExpiry 45m → 1h snapped', () => {
+    const r = resolveExpiry('45m');
+    assert.ok(r);
+    assert.equal(r.bucket, '1h');
+    assert.equal(r.snapped, true);
+    assert.equal(r.capped, false);
+  });
+
+  await test('resolveExpiry 2h30m → 24h', () => {
+    const r = resolveExpiry('2h30m');
+    assert.ok(r);
+    assert.equal(r.bucket, '24h');
+    assert.equal(r.snapped, true);
+  });
+
+  await test('resolveExpiry 1h exact', () => {
+    const r = resolveExpiry('1h');
+    assert.ok(r);
+    assert.equal(r.bucket, '1h');
+    assert.equal(r.snapped, false);
+  });
+
+  await test('resolveExpiry 60m → 1h snapped:false', () => {
+    const r = resolveExpiry('60m');
+    assert.ok(r);
+    assert.equal(r.bucket, '1h');
+    assert.equal(r.snapped, false);
+    assert.equal(r.requestedMs, 3_600_000);
+  });
+
+  await test('resolveExpiry 3d → 7d', () => {
+    const r = resolveExpiry('3d');
+    assert.ok(r);
+    assert.equal(r.bucket, '7d');
+    assert.equal(r.snapped, true);
+  });
+
+  await test('resolveExpiry 8d → 30d', () => {
+    const r = resolveExpiry('8d');
+    assert.ok(r);
+    assert.equal(r.bucket, '30d');
+  });
+
+  await test('resolveExpiry 2w → 30d', () => {
+    const r = resolveExpiry('2w');
+    assert.ok(r);
+    assert.equal(r.bucket, '30d');
+  });
+
+  await test('resolveExpiry 40d → 1y', () => {
+    const r = resolveExpiry('40d');
+    assert.ok(r);
+    assert.equal(r.bucket, '1y');
+    assert.equal(r.capped, false);
+  });
+
+  await test('resolveExpiry 60w → 1y capped:true', () => {
+    const r = resolveExpiry('60w');
+    assert.ok(r);
+    assert.equal(r.bucket, '1y');
+    assert.equal(r.capped, true);
+    assert.equal(r.snapped, true);
+  });
+
+  await test('resolveExpiry invalid foo → null', () => {
+    assert.equal(resolveExpiry('foo'), null);
+  });
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #28

Two snips.sh-parity features for the `cloakbin` CLI:

## 1. File-extension language auto-detect
When a file argument is given and `--lang` is not set, the syntax language is inferred from the extension (`.py`→python, `.ts`→typescript, `.rs`→rust, `Dockerfile`→dockerfile, ~65 mappings in `src/lang-detect.js`). Explicit `--lang` always overrides; piped stdin stays plaintext. All values satisfy the server's `^[a-zA-Z0-9_-]{1,30}$` validation.

## 2. Flexible/human expiry input
`--expiry` now accepts durations like `2h30m`, `1w2d`, `3d`, `45m` (units `w`/`d`/`h`/`m`). Since the free anonymous API only supports fixed buckets (`1h/24h/7d/30d/1y`), durations snap **up** to the smallest bucket that fits (capped at `1y`) so shared links never die earlier than asked. The applied bucket is printed to stderr when it differs:

```
⏳ expiry 3d → applied 7d (free tier uses fixed buckets; exact expiry is a premium feature)
```

Exact bucket strings still pass through unchanged. stdout remains URL-only.

## Testing
- 37 tests green (9 existing round-trip + 28 new unit tests for duration parsing/snapping and extension mapping)
- Live smoke tests against cloakbin.com: `t.py --expiry 3d` → server metadata confirms `language: python`, expiry 7 days out; `echo hi | cloakbin --expiry 45m` → 1h, roundtrip `get` decrypts correctly
- `src/crypto.js` untouched