### PR TITLE
test: cover language detection

### DIFF
--- a/src/lib/detectLanguage.test.ts
+++ b/src/lib/detectLanguage.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectLanguage } from './detectLanguage';
+
+describe('detectLanguage', () => {
+	const cases = [
+		{
+			name: 'JavaScript',
+			code: `
+				function greet(name) {
+					const message = \`Hello, \${name}!\`;
+					console.log(message);
+					return message;
+				}
+			`,
+			expected: 'javascript'
+		},
+		{
+			name: 'Python',
+			code: `
+				def greet(name: str) -> str:
+					message = f"Hello, {name}!"
+					print(message)
+					return message
+			`,
+			expected: 'python'
+		},
+		{
+			name: 'JSON',
+			code: `
+				{
+					"name": "cloakbin",
+					"private": true,
+					"features": ["encrypted", "pastebin"]
+				}
+			`,
+			expected: 'json'
+		},
+		{
+			name: 'Rust',
+			code: `
+				fn main() {
+					let values: Vec<i32> = vec![1, 2, 3];
+					for value in values.iter() {
+						println!("value={}", value);
+					}
+				}
+			`,
+			expected: 'rust'
+		}
+	];
+
+	it.each(cases)('detects $name snippets', ({ code, expected }) => {
+		expect(detectLanguage(code)).toBe(expected);
+	});
+
+	it('falls back to plaintext for empty or low-confidence input', () => {
+		expect(detectLanguage('')).toBe('plaintext');
+		expect(detectLanguage('   \n\t')).toBe('plaintext');
+		expect(detectLanguage('just a short sentence without code')).toBe('plaintext');
+	});
+});


### PR DESCRIPTION
Fixes #43.

## Summary
- add a Vitest table test for `src/lib/detectLanguage.ts`
- cover JavaScript, Python, JSON, and Rust snippets
- assert plaintext fallback for empty, whitespace-only, and low-confidence prose inputs

## Validation
- `./node_modules/.bin/vitest run src/lib/detectLanguage.test.ts`
- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/prettier --check src/lib/detectLanguage.test.ts`
- `./node_modules/.bin/eslint src/lib/detectLanguage.test.ts src/lib/detectLanguage.ts`
- `./node_modules/.bin/svelte-kit sync && ./node_modules/.bin/svelte-check --tsconfig ./tsconfig.json` (passes with existing Svelte warnings)
- `DB_TYPE=memory ./node_modules/.bin/vite build` (passes with existing Svelte/Vite warnings)
- `git diff --check`
- `rg -n "Karim13014|claude-code@anthropic.com" .`

## Notes
- `corepack pnpm install --frozen-lockfile` populated dependencies but exits nonzero in this environment because pnpm blocks unapproved build scripts for `esbuild` and `sharp`; validation used local binaries from the installed dependency tree without changing approval settings.