### PR TITLE
Add health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ CloakBin is fully open source. Deploy your own instance:
 3. Set up MongoDB (Atlas free tier works)
 4. Configure environment variables
 
+### Health Check
+
+For container orchestrators (Docker, Kubernetes, Fly.io, Railway, etc.) to monitor readiness and trigger restarts:
+
+**Healthy** — `200`:
+```json
+{ "ok": true, "db": "mongodb" }
+```
+
+**Unhealthy** — `503` (e.g. database unreachable):
+```json
+{ "ok": false, "error": "database unavailable" }
+```
+
+This endpoint is excluded from rate limiting so orchestrators can poll it frequently.
+
 ## Deploy CloakBin at your company
 
 CloakBin is free to self-host. If you want it running on your own infrastructure without doing the setup yourself, I can handle it for you.

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -84,10 +84,7 @@ function isRateLimited(
 	const key = ip;
 	const entry = rateLimitStore.get(key);
 
-	//Skip rate limiting for health checks
-	if (path === '/api/health') {
-		return resolve(event);
-	}
+
 
 	// First request or window expired
 	if (!entry || now > entry.resetTime) {
@@ -145,50 +142,52 @@ export const handle: Handle = async ({ event, resolve }) => {
 	// ============================================
 	// HEALTH CHECK — exclude from rate limiting and CSRF entirely
 	// ============================================
-	if (event.url.pathname === '/api/health') {
-		return resolve(event);
-	}
+	const isHealthCheck = event.url.pathname === '/api/health';
 
 	// ============================================
 	// RATE LIMITING
 	// ============================================
-	const ip = getClientIP(event);
-	const path = event.url.pathname;
-	const method = event.request.method;
+	if (!isHealthCheck) {
+		const ip = getClientIP(event);
+		const path = event.url.pathname;
+		const method = event.request.method;
 
-	// Determine which rate limit to apply
-	let limit: (typeof RATE_LIMITS)[keyof typeof RATE_LIMITS] = RATE_LIMITS.default;
-	let limitType = 'default';
+		// Determine which rate limit to apply
+		let limit: (typeof RATE_LIMITS)[keyof typeof RATE_LIMITS] = RATE_LIMITS.default;
+		let limitType = 'default';
 
-	if (method === 'POST' && path === '/api/paste') {
-		limit = RATE_LIMITS.createPaste;
-		limitType = 'createPaste';
-	} else if (method === 'GET' && path.startsWith('/api/paste/')) {
-		limit = RATE_LIMITS.readPaste;
-		limitType = 'readPaste';
-	}
+		if (method === 'POST' && path === '/api/paste') {
+			limit = RATE_LIMITS.createPaste;
+			limitType = 'createPaste';
+		} else if (method === 'GET' && path.startsWith('/api/paste/')) {
+			limit = RATE_LIMITS.readPaste;
+			limitType = 'readPaste';
+		}
 
-	// Check rate limit
-	const { limited, remaining, resetIn } = isRateLimited(`${ip}:${limitType}`, limit);
+		// Check rate limit
+		const { limited, resetIn } = isRateLimited(`${ip}:${limitType}`, limit);
 
-	if (limited) {
-		console.warn(`Rate limited: IP=${ip}, type=${limitType}, resetIn=${Math.ceil(resetIn / 1000)}s`);
-		return new Response(
-			JSON.stringify({
-				error: 'Too many requests',
-				retryAfter: Math.ceil(resetIn / 1000)
-			}),
-			{
-				status: 429,
-				headers: {
-					'Content-Type': 'application/json',
-					'Retry-After': String(Math.ceil(resetIn / 1000)),
-					'X-RateLimit-Remaining': '0',
-					'X-RateLimit-Reset': String(Math.ceil(resetIn / 1000))
+		if (limited) {
+			console.warn(`Rate limited: IP=${ip}, type=${limitType}, resetIn=${Math.ceil(resetIn / 1000)}s`);
+			return new Response(
+				JSON.stringify({
+					error: 'Too many requests',
+					retryAfter: Math.ceil(resetIn / 1000)
+				}),
+				{
+					status: 429,
+					headers: {
+						'Content-Type': 'application/json',
+						'Retry-After': String(Math.ceil(resetIn / 1000)),
+						'X-RateLimit-Remaining': '0',
+						'X-RateLimit-Reset': String(Math.ceil(resetIn / 1000))
+					}
 				}
-			}
-		);
+			);
+		}
+
 	}
+
 
 	// ============================================
 	// CSRF PROTECTION
@@ -197,7 +196,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 	// came from our own site by checking the Origin header.
 	// This prevents evil.com from tricking users into making requests.
 
-	if (['POST', 'PUT', 'DELETE', 'PATCH'].includes(event.request.method)) {
+	if (!isHealthCheck && ['POST', 'PUT', 'DELETE', 'PATCH'].includes(event.request.method)) {
 		const origin = event.request.headers.get('origin');
 		const host = event.request.headers.get('host');
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -84,6 +84,11 @@ function isRateLimited(
 	const key = ip;
 	const entry = rateLimitStore.get(key);
 
+	//Skip rate limiting for health checks
+	if (path === '/api/health') {
+		return resolve(event);
+	}
+
 	// First request or window expired
 	if (!entry || now > entry.resetTime) {
 		rateLimitStore.set(key, {
@@ -135,6 +140,13 @@ export const handle: Handle = async ({ event, resolve }) => {
 		if (verifyAdminSession(adminSession, env.ADMIN_USER, env.ADMIN_PASS)) {
 			event.locals.isAdmin = true;
 		}
+	}
+
+	// ============================================
+	// HEALTH CHECK — exclude from rate limiting and CSRF entirely
+	// ============================================
+	if (event.url.pathname === '/api/health') {
+		return resolve(event);
 	}
 
 	// ============================================

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -1,0 +1,12 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { db } from '$lib/db';
+
+export const GET: RequestHandler = async () => {
+    try {
+        await db.healthCheck();
+        return json({ ok: true, db: 'mongodb' }, { status: 200 }); 
+    } catch (err) {
+        return json({ ok: false, error: 'database unavailable' }, { status: 503 });
+    }
+};

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -4,9 +4,12 @@ import { db } from '$lib/db';
 
 export const GET: RequestHandler = async () => {
     try {
-        await db.healthCheck();
-        return json({ ok: true, db: 'mongodb' }, { status: 200 }); 
-    } catch (err) {
+        const result = await db.healthCheck();
+        if (!result.success) {
+            return json({ ok: false, error: 'database unavailable' }, { status: 503 });
+        }
+        return json({ ok: true }, { status: 200 });
+    } catch {
         return json({ ok: false, error: 'database unavailable' }, { status: 503 });
     }
 };


### PR DESCRIPTION
## Summary

Adds a new `/api/health` endpoint for container health checks.

### Changes
- Added `GET /api/health`
- Calls `db.healthCheck()`
- Returns `200` when healthy
- Returns `503` when the database is unavailable
- Excluded `/api/health` from rate limiting
- Updated health check documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a health check endpoint that reports service and database availability.
  * Returns clear healthy (`200`) or unavailable (`503`) JSON responses.
  * Health check traffic bypasses rate limiting and CSRF processing to support frequent polling.

* **Documentation**
  * Added a “Health Check” section documenting the endpoint, expected response formats, and monitoring behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `GET /api/health` endpoint that probes the database and returns `200`/`503` for container orchestrators, along with a bypass in the server handle hook to exclude the path from rate limiting and CSRF checks.

- **New route** (`src/routes/api/health/+server.ts`): calls `db.healthCheck()`, catches errors, and returns structured JSON — logic is correct and the try/catch covers both explicit failure results and thrown exceptions.
- **Hook changes** (`src/hooks.server.ts`): wraps rate-limiting and CSRF blocks in `!isHealthCheck` guards; the CSRF guard is technically redundant since health is GET-only, but it is harmless.
- **README**: documents `{ \"ok\": true, \"db\": \"mongodb\" }` as the healthy response, but the implementation returns `{ ok: true }` without the `db` field.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core health-check logic and hook bypass are both correct.

The health check route and hook guard work correctly. The one concrete mismatch — the README documents a `db` field in the healthy response that the implementation never emits — is worth fixing before external consumers start depending on that shape.

src/routes/api/health/+server.ts — the response body should be reconciled with what the README documents.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/api/health/+server.ts | New health check endpoint; response body is missing the documented `db` field and the file lacks a trailing newline. |
| src/hooks.server.ts | Wraps rate-limiting and CSRF logic in `!isHealthCheck` guard; functionally correct, with minor cosmetic issues (extra blank lines). |
| README.md | Documents `{ "ok": true, "db": "mongodb" }` as the healthy response body, but the implementation returns `{ ok: true }` without the `db` field. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Orchestrator as Container Orchestrator
    participant Hooks as hooks.server.ts (Handle)
    participant Health as /api/health
    participant DB as Database

    Orchestrator->>Hooks: GET /api/health
    Note over Hooks: isHealthCheck = true
    Hooks->>Health: resolve(event)
    Health->>DB: db.healthCheck()
    alt DB reachable
        DB-->>Health: success true
        Health-->>Orchestrator: 200 ok true
    else DB unreachable
        DB-->>Health: success false or throws
        Health-->>Orchestrator: 503 ok false
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Froutes%2Fapi%2Fhealth%2F%2Bserver.ts%3A11%0AThe%20README%20documents%20the%20healthy%20response%20as%20%60%7B%20%22ok%22%3A%20true%2C%20%22db%22%3A%20%22mongodb%22%20%7D%60%2C%20but%20the%20implementation%20only%20returns%20%60%7B%20ok%3A%20true%20%7D%60%20%E2%80%94%20the%20%60db%60%20field%20is%20never%20included.%20Consumers%20relying%20on%20that%20field%20to%20identify%20which%20backend%20is%20healthy%20will%20see%20it%20missing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20json%28%7B%20ok%3A%20true%2C%20db%3A%20result.data%20%3F%3F%20'unknown'%20%7D%2C%20%7B%20status%3A%20200%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Froutes%2Fapi%2Fhealth%2F%2Bserver.ts%3A13-15%0AFile%20is%20missing%20a%20trailing%20newline%2C%20which%20violates%20the%20POSIX%20text-file%20convention%20and%20can%20cause%20noise%20in%20diffs.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20json%28%7B%20ok%3A%20false%2C%20error%3A%20'database%20unavailable'%20%7D%2C%20%7B%20status%3A%20503%20%7D%29%3B%0A%20%20%20%20%7D%0A%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fhooks.server.ts%3A85-89%0ATwo%20extra%20blank%20lines%20were%20accidentally%20introduced%20inside%20%60isRateLimited%60%3B%20they%20add%20noise%20without%20meaning.%0A%0A%60%60%60suggestion%0A%09const%20entry%20%3D%20rateLimitStore.get%28key%29%3B%0A%0A%09%2F%2F%20First%20request%20or%20window%20expired%0A%60%60%60%0A%0A&repo=ishannaik%2Fcloakbin&pr=154&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22add-health-endpoint%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22add-health-endpoint%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Froutes%2Fapi%2Fhealth%2F%2Bserver.ts%3A11%0AThe%20README%20documents%20the%20healthy%20response%20as%20%60%7B%20%22ok%22%3A%20true%2C%20%22db%22%3A%20%22mongodb%22%20%7D%60%2C%20but%20the%20implementation%20only%20returns%20%60%7B%20ok%3A%20true%20%7D%60%20%E2%80%94%20the%20%60db%60%20field%20is%20never%20included.%20Consumers%20relying%20on%20that%20field%20to%20identify%20which%20backend%20is%20healthy%20will%20see%20it%20missing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20json%28%7B%20ok%3A%20true%2C%20db%3A%20result.data%20%3F%3F%20'unknown'%20%7D%2C%20%7B%20status%3A%20200%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Froutes%2Fapi%2Fhealth%2F%2Bserver.ts%3A13-15%0AFile%20is%20missing%20a%20trailing%20newline%2C%20which%20violates%20the%20POSIX%20text-file%20convention%20and%20can%20cause%20noise%20in%20diffs.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20json%28%7B%20ok%3A%20false%2C%20error%3A%20'database%20unavailable'%20%7D%2C%20%7B%20status%3A%20503%20%7D%29%3B%0A%20%20%20%20%7D%0A%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fhooks.server.ts%3A85-89%0ATwo%20extra%20blank%20lines%20were%20accidentally%20introduced%20inside%20%60isRateLimited%60%3B%20they%20add%20noise%20without%20meaning.%0A%0A%60%60%60suggestion%0A%09const%20entry%20%3D%20rateLimitStore.get%28key%29%3B%0A%0A%09%2F%2F%20First%20request%20or%20window%20expired%0A%60%60%60%0A%0A&repo=ishannaik%2Fcloakbin&pr=154&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Froutes%2Fapi%2Fhealth%2F%2Bserver.ts%3A11%0AThe%20README%20documents%20the%20healthy%20response%20as%20%60%7B%20%22ok%22%3A%20true%2C%20%22db%22%3A%20%22mongodb%22%20%7D%60%2C%20but%20the%20implementation%20only%20returns%20%60%7B%20ok%3A%20true%20%7D%60%20%E2%80%94%20the%20%60db%60%20field%20is%20never%20included.%20Consumers%20relying%20on%20that%20field%20to%20identify%20which%20backend%20is%20healthy%20will%20see%20it%20missing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20json%28%7B%20ok%3A%20true%2C%20db%3A%20result.data%20%3F%3F%20'unknown'%20%7D%2C%20%7B%20status%3A%20200%20%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Froutes%2Fapi%2Fhealth%2F%2Bserver.ts%3A13-15%0AFile%20is%20missing%20a%20trailing%20newline%2C%20which%20violates%20the%20POSIX%20text-file%20convention%20and%20can%20cause%20noise%20in%20diffs.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20json%28%7B%20ok%3A%20false%2C%20error%3A%20'database%20unavailable'%20%7D%2C%20%7B%20status%3A%20503%20%7D%29%3B%0A%20%20%20%20%7D%0A%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fhooks.server.ts%3A85-89%0ATwo%20extra%20blank%20lines%20were%20accidentally%20introduced%20inside%20%60isRateLimited%60%3B%20they%20add%20noise%20without%20meaning.%0A%0A%60%60%60suggestion%0A%09const%20entry%20%3D%20rateLimitStore.get%28key%29%3B%0A%0A%09%2F%2F%20First%20request%20or%20window%20expired%0A%60%60%60%0A%0A&pr=154&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/routes/api/health/+server.ts:11
The README documents the healthy response as `{ "ok": true, "db": "mongodb" }`, but the implementation only returns `{ ok: true }` — the `db` field is never included. Consumers relying on that field to identify which backend is healthy will see it missing.

```suggestion
        return json({ ok: true, db: result.data ?? 'unknown' }, { status: 200 });
```

### Issue 2 of 3
src/routes/api/health/+server.ts:13-15
File is missing a trailing newline, which violates the POSIX text-file convention and can cause noise in diffs.

```suggestion
        return json({ ok: false, error: 'database unavailable' }, { status: 503 });
    }
};
```

### Issue 3 of 3
src/hooks.server.ts:85-89
Two extra blank lines were accidentally introduced inside `isRateLimited`; they add noise without meaning.

```suggestion
	const entry = rateLimitStore.get(key);

	// First request or window expired
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: return 503 on health check DB failu..."](https://github.com/ishannaik/cloakbin/commit/20b309ca9892fe0f5ddacc34f33c1554821ea5dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45973706)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->