### PR TITLE
fix(security): allowlist paste language on POST /api/paste

### DIFF
--- a/src/lib/languages.test.ts
+++ b/src/lib/languages.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+	normalizePasteLanguage,
+	isAllowedPasteLanguage,
+	PASTE_LANGUAGE_SET,
+	LANGUAGE_PICKER_OPTIONS
+} from './languages';
+
+describe('normalizePasteLanguage', () => {
+	it('falls back to plaintext for missing / non-string values', () => {
+		expect(normalizePasteLanguage(undefined)).toBe('plaintext');
+		expect(normalizePasteLanguage(null)).toBe('plaintext');
+		expect(normalizePasteLanguage(42)).toBe('plaintext');
+		expect(normalizePasteLanguage('')).toBe('plaintext');
+		expect(normalizePasteLanguage('   ')).toBe('plaintext');
+		expect(normalizePasteLanguage('auto')).toBe('plaintext');
+	});
+
+	it('accepts known languages case-insensitively', () => {
+		expect(normalizePasteLanguage('javascript')).toBe('javascript');
+		expect(normalizePasteLanguage('Python')).toBe('python');
+		expect(normalizePasteLanguage('PLAINTEXT')).toBe('plaintext');
+	});
+
+	it('maps aliases to canonical ids', () => {
+		expect(normalizePasteLanguage('js')).toBe('javascript');
+		expect(normalizePasteLanguage('ts')).toBe('typescript');
+		expect(normalizePasteLanguage('py')).toBe('python');
+		expect(normalizePasteLanguage('yml')).toBe('yaml');
+	});
+
+	it('rejects unknown / malicious language strings', () => {
+		expect(normalizePasteLanguage('maliciousXYZ')).toBe('plaintext');
+		expect(normalizePasteLanguage('<script>alert(1)</script>')).toBe('plaintext');
+		expect(normalizePasteLanguage('../../etc/passwd')).toBe('plaintext');
+		expect(normalizePasteLanguage('a'.repeat(500))).toBe('plaintext');
+	});
+});
+
+describe('isAllowedPasteLanguage', () => {
+	it('returns true for allowlisted ids and aliases', () => {
+		expect(isAllowedPasteLanguage('rust')).toBe(true);
+		expect(isAllowedPasteLanguage('rs')).toBe(true);
+	});
+
+	it('returns false for unknown ids', () => {
+		expect(isAllowedPasteLanguage('maliciousXYZ')).toBe(false);
+	});
+});
+
+describe('LANGUAGE_PICKER_OPTIONS', () => {
+	it('only offers allowlisted values (plus auto)', () => {
+		for (const opt of LANGUAGE_PICKER_OPTIONS) {
+			if (opt.value === 'auto') continue;
+			expect(PASTE_LANGUAGE_SET.has(opt.value)).toBe(true);
+		}
+	});
+});

--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -1,0 +1,122 @@
+/**
+ * Shared paste language allowlist.
+ *
+ * Kept in one place so POST /api/paste, CodeMirror loaders, and the
+ * language picker stay aligned. Unknown values fall back to plaintext.
+ */
+
+/** Canonical language ids accepted for storage / highlighting. */
+export const PASTE_LANGUAGES = [
+	'plaintext',
+	'javascript',
+	'typescript',
+	'python',
+	'json',
+	'html',
+	'xml',
+	'css',
+	'markdown',
+	'sql',
+	'java',
+	'cpp',
+	'c',
+	'rust',
+	'go',
+	'php',
+	'yaml',
+	'ruby',
+	'csharp',
+	'kotlin',
+	'swift',
+	'scala',
+	'bash',
+	'shell',
+	// Extra ids produced by CLI EXT_MAP / future highlighters — still safe to store
+	'tsx',
+	'jsx',
+	'toml',
+	'scss',
+	'lua',
+	'perl',
+	'r',
+	'dart',
+	'haskell',
+	'elixir',
+	'erlang',
+	'clojure',
+	'vue',
+	'svelte',
+	'ini',
+	'powershell',
+	'batch',
+	'diff',
+	'latex',
+	'zig',
+	'nim',
+	'protobuf',
+	'graphql',
+	'hcl',
+	'dockerfile',
+	'makefile'
+] as const;
+
+export type PasteLanguage = (typeof PASTE_LANGUAGES)[number];
+
+export const PASTE_LANGUAGE_SET: ReadonlySet<string> = new Set(PASTE_LANGUAGES);
+
+/** Short / alternate ids → canonical paste language id. */
+export const LANGUAGE_ALIASES: Readonly<Record<string, string>> = {
+	js: 'javascript',
+	ts: 'typescript',
+	py: 'python',
+	md: 'markdown',
+	yml: 'yaml',
+	rs: 'rust',
+	htm: 'html',
+	sh: 'bash',
+	zsh: 'bash'
+};
+
+/** Options shown in the create-page language picker (UI only). */
+export const LANGUAGE_PICKER_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+	{ value: 'auto', label: 'Auto-detect' },
+	{ value: 'javascript', label: 'JavaScript' },
+	{ value: 'typescript', label: 'TypeScript' },
+	{ value: 'python', label: 'Python' },
+	{ value: 'rust', label: 'Rust' },
+	{ value: 'go', label: 'Go' },
+	{ value: 'java', label: 'Java' },
+	{ value: 'cpp', label: 'C/C++' },
+	{ value: 'csharp', label: 'C#' },
+	{ value: 'php', label: 'PHP' },
+	{ value: 'ruby', label: 'Ruby' },
+	{ value: 'swift', label: 'Swift' },
+	{ value: 'kotlin', label: 'Kotlin' },
+	{ value: 'sql', label: 'SQL' },
+	{ value: 'html', label: 'HTML' },
+	{ value: 'css', label: 'CSS' },
+	{ value: 'json', label: 'JSON' },
+	{ value: 'yaml', label: 'YAML' },
+	{ value: 'markdown', label: 'Markdown' },
+	{ value: 'bash', label: 'Bash/Shell' },
+	{ value: 'plaintext', label: 'Plain Text' }
+];
+
+/**
+ * Normalize a client-supplied language string for storage.
+ * Unknown / non-string values become `plaintext` (never stored raw).
+ */
+export function normalizePasteLanguage(language: unknown): string {
+	if (typeof language !== 'string') return 'plaintext';
+	const raw = language.trim().toLowerCase();
+	if (!raw || raw === 'auto') return 'plaintext';
+
+	const canonical = LANGUAGE_ALIASES[raw] ?? raw;
+	return PASTE_LANGUAGE_SET.has(canonical) ? canonical : 'plaintext';
+}
+
+export function isAllowedPasteLanguage(language: string): boolean {
+	const raw = language.trim().toLowerCase();
+	const canonical = LANGUAGE_ALIASES[raw] ?? raw;
+	return PASTE_LANGUAGE_SET.has(canonical);
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
 	import { EditorView, keymap } from '@codemirror/view';
 	import type { Extension } from '@codemirror/state';
 	import type { LanguageSupport } from '@codemirror/language';
+	import { LANGUAGE_PICKER_OPTIONS, isAllowedPasteLanguage } from '$lib/languages';
 	import {
 		dracula,
 		cobalt,
@@ -32,6 +33,9 @@
 	// Load language extension dynamically
 	async function loadLanguageExtension(lang: string): Promise<LanguageSupport | null> {
 		try {
+			if (!isAllowedPasteLanguage(lang) && lang !== 'auto') {
+				return null;
+			}
 			switch (lang) {
 				case 'javascript':
 				case 'js':
@@ -130,30 +134,8 @@
 	let burnAfterRead = $state(false);
 	let selectedLanguage = $state('auto'); // 'auto' means auto-detect language using highlight.js
 
-	// Available languages for manual selection
-	const languages = [
-		{ value: 'auto', label: 'Auto-detect' },
-		{ value: 'javascript', label: 'JavaScript' },
-		{ value: 'typescript', label: 'TypeScript' },
-		{ value: 'python', label: 'Python' },
-		{ value: 'rust', label: 'Rust' },
-		{ value: 'go', label: 'Go' },
-		{ value: 'java', label: 'Java' },
-		{ value: 'cpp', label: 'C/C++' },
-		{ value: 'csharp', label: 'C#' },
-		{ value: 'php', label: 'PHP' },
-		{ value: 'ruby', label: 'Ruby' },
-		{ value: 'swift', label: 'Swift' },
-		{ value: 'kotlin', label: 'Kotlin' },
-		{ value: 'sql', label: 'SQL' },
-		{ value: 'html', label: 'HTML' },
-		{ value: 'css', label: 'CSS' },
-		{ value: 'json', label: 'JSON' },
-		{ value: 'yaml', label: 'YAML' },
-		{ value: 'markdown', label: 'Markdown' },
-		{ value: 'bash', label: 'Bash/Shell' },
-		{ value: 'plaintext', label: 'Plain Text' }
-	];
+	// Available languages for manual selection (shared allowlist)
+	const languages = LANGUAGE_PICKER_OPTIONS;
 
 	// Cleanup references (need to be outside onMount for onDestroy to access)
 	let saveInterval: ReturnType<typeof setInterval>;

--- a/src/routes/api/paste/+server.ts
+++ b/src/routes/api/paste/+server.ts
@@ -17,6 +17,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { db } from '$lib/db';
+import { normalizePasteLanguage } from '$lib/languages';
 
 const MAX_CONTENT_SIZE = 100_000_000; // 100MB in characters
 
@@ -84,6 +85,9 @@ export const POST: RequestHandler = async ({ request }) => {
 		// Calculate expiration date
 		const expiresAt = new Date(Date.now() + EXPIRY_DURATIONS[expiry]);
 
+		// Allowlist language ids; unknown / malicious values fall back to plaintext
+		const safeLanguage = normalizePasteLanguage(language);
+
 		// Create paste in database
 		const result = await db.createPaste({
 			content,
@@ -91,7 +95,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			hasPassword: !!salt,
 			salt: salt,
 			burnAfterRead: burnAfterRead ?? false,
-			language: language ?? 'plaintext'
+			language: safeLanguage
 		});
 
 		if (!result.success) {

--- a/src/routes/p/[id]/+page.svelte
+++ b/src/routes/p/[id]/+page.svelte
@@ -8,6 +8,7 @@
 	import { oneDark } from '@codemirror/theme-one-dark';
 	import type { Extension } from '@codemirror/state';
 	import type { LanguageSupport } from '@codemirror/language';
+	import { isAllowedPasteLanguage } from '$lib/languages';
 	import {
 		dracula,
 		cobalt,
@@ -71,6 +72,10 @@
 	// Load language extension dynamically
 	async function loadLanguageExtension(lang: string): Promise<LanguageSupport> {
 		try {
+			// Guard: only load highlighters for allowlisted language ids
+			if (!isAllowedPasteLanguage(lang)) {
+				return javascript();
+			}
 			switch (lang) {
 				case 'javascript':
 				case 'js':


### PR DESCRIPTION
## Summary
Closes #132.

`POST /api/paste` previously stored the client-supplied `language` string as-is (only defaulting when missing). Arbitrary values waste storage and can surprise the CodeMirror loader on the view page.

### Changes
- New shared module `src/lib/languages.ts`:
  - `PASTE_LANGUAGES` allowlist
  - `normalizePasteLanguage()` → unknown values become `plaintext`
  - `LANGUAGE_PICKER_OPTIONS` for the create UI
  - `isAllowedPasteLanguage()` for CodeMirror guards
- `src/routes/api/paste/+server.ts` stores only normalized language ids
- Create + view pages import the shared allowlist / guard
- Unit tests in `src/lib/languages.test.ts` (includes `maliciousXYZ` case)

## Test plan
- [x] `pnpm exec vitest run src/lib/languages.test.ts` → **7 passed**
- [x] `pnpm test` → **25 passed** (3 files)
- [x] `pnpm check` → **0 errors** (8 pre-existing a11y warnings in admin pages only)
- [ ] Manual: POST with `language: "maliciousXYZ"` stores `plaintext`

## Notes
Unknown values fall back to `plaintext` (not 400) so legitimate clients with slight naming drift keep working while malicious payloads never land in storage.

Netlify/Vercel preview failures appear to be deploy-auth configuration for forks (not related to this diff). GitGuardian Security Checks: SUCCESS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added centralized support for recognized paste languages, including aliases and picker options.
  - Improved language selection with consistent validation across paste creation and viewing.
- **Bug Fixes**
  - Invalid, unknown, empty, or unsafe language values now safely fall back to plaintext.
  - Unsupported language selections no longer attempt to load unavailable syntax highlighting.
- **Tests**
  - Added coverage for language normalization, validation, aliases, and picker options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a centralized language allowlist (`src/lib/languages.ts`) and wires it into the paste creation API, the CodeMirror loader on both the create and view pages, and the language picker UI, replacing the previous behavior of storing client-supplied language strings verbatim.

- **`normalizePasteLanguage()`** sanitizes the incoming `language` field on `POST /api/paste`: non-strings, empty values, `'auto'`, unknown identifiers, and aliases all resolve to a canonical PASTE_LANGUAGES entry or fall back to `'plaintext'`.
- **`isAllowedPasteLanguage()`** guards `loadLanguageExtension()` on both pages so only allowlisted ids trigger dynamic CodeMirror imports; unknown values (including old DB rows stored with `'auto'`) fall back to `javascript()`, matching prior behavior.
- The create page's inline language array is replaced by the shared `LANGUAGE_PICKER_OPTIONS`, eliminating the previously flagged drift risk between the picker and the allowlist.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the allowlist logic is correct, the normalization handles all edge cases, and behavior for existing pastes is preserved.

The core normalization path is well-tested and handles non-strings, empty values, aliases, case differences, and injection strings correctly. The guard added to both pages' CodeMirror loaders preserves existing fallback behavior for old DB rows. No regressions were found in the changed paths.

No files require special attention. The one minor note is the alias lookup in `src/lib/languages.ts` which could use `Object.hasOwn` for strict own-property access, but is safe in practice.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/languages.ts | New shared module introducing PASTE_LANGUAGES allowlist, normalizePasteLanguage(), isAllowedPasteLanguage(), LANGUAGE_ALIASES, and LANGUAGE_PICKER_OPTIONS. Logic is correct and handles all edge cases (non-string, empty, alias resolution). Minor: alias lookup uses direct property access which can return inherited prototype properties, though the downstream Set.has() check keeps it safe. |
| src/lib/languages.test.ts | 7 tests covering normalizePasteLanguage (edge cases, aliases, malicious inputs) and basic isAllowedPasteLanguage/LANGUAGE_PICKER_OPTIONS checks. Coverage for normalizePasteLanguage is thorough; isAllowedPasteLanguage tests are thin (only 'rust'/'rs'/malicious, missing 'plaintext' and 'auto' paths used by the view page guard). |
| src/routes/api/paste/+server.ts | Integrates normalizePasteLanguage() before the db.createPaste call; replaces the raw language ?? 'plaintext' assignment. Change is minimal and correct. |
| src/routes/+page.svelte | Replaces the inline language options array with LANGUAGE_PICKER_OPTIONS and adds an isAllowedPasteLanguage guard in loadLanguageExtension. The $effect already filters 'auto'/'plaintext' before calling loadLanguageExtension, so the guard is defensive depth only. |
| src/routes/p/[id]/+page.svelte | Adds isAllowedPasteLanguage guard before the CodeMirror switch; unknown language IDs (including old 'auto' pastes in the DB) fall back to javascript() highlighting, matching pre-PR behavior. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as POST /api/paste
    participant N as normalizePasteLanguage()
    participant DB as Database

    Client->>API: "{ content, language: "maliciousXYZ" | "auto" | "js" | ... }"
    API->>N: normalizePasteLanguage(language)
    alt known canonical id (e.g. "javascript")
        N-->>API: "javascript"
    else known alias (e.g. "js" → "javascript")
        N-->>API: "javascript"
    else unknown / "auto" / non-string
        N-->>API: "plaintext"
    end
    API->>DB: "createPaste({ language: safeLanguage })"

    participant VP as View Page
    participant G as isAllowedPasteLanguage()
    participant CM as CodeMirror loader

    DB-->>VP: data.language (always a canonical id)
    VP->>G: isAllowedPasteLanguage(lang)
    alt allowlisted
        G-->>VP: true
        VP->>CM: dynamic import for lang
    else not allowlisted (old "auto" rows)
        G-->>VP: false
        VP->>CM: javascript() fallback
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(security): allowlist paste language ..."](https://github.com/ishannaik/cloakbin/commit/b442ec44eaa78e5e141ad5d54653d9e196f336de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46228469)</sub>

<!-- /greptile_comment -->