### PR TITLE
docs(security): add SECURITY-MODEL.md for zero-knowledge design

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The encryption key lives in the URL fragment (`#`), which **browsers never send 
 - **Key Derivation**: PBKDF2 with 100,000 iterations (for password-protected pastes)
 - **Random Generation**: Web Crypto API (`crypto.getRandomValues`)
 
-For a deeper walkthrough of key generation, ciphertext formats (v0/v1), password mode, burn-after-read atomicity, and the threat model (mapped to the current code), see **[docs/SECURITY-MODEL.md](docs/SECURITY-MODEL.md)**.
+Full architecture write-up (ciphertext formats, fragment keys, threat model): **[docs/SECURITY-MODEL.md](docs/SECURITY-MODEL.md)**. Vulnerability reporting: **[SECURITY.md](SECURITY.md)**.
 
 ## Verify the Zero-Knowledge Claim Yourself
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The encryption key lives in the URL fragment (`#`), which **browsers never send 
 - **Key Derivation**: PBKDF2 with 100,000 iterations (for password-protected pastes)
 - **Random Generation**: Web Crypto API (`crypto.getRandomValues`)
 
+For a deeper walkthrough of key generation, ciphertext formats (v0/v1), password mode, burn-after-read atomicity, and the threat model (mapped to the current code), see **[docs/SECURITY-MODEL.md](docs/SECURITY-MODEL.md)**.
+
 ## Verify the Zero-Knowledge Claim Yourself
 
 You can check the guarantee yourself, in your browser:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,3 +32,7 @@ Security fixes are applied to the latest `main` branch and the most recent tagge
 ## Response
 
 We aim to acknowledge a valid report within a few days and to address confirmed high-impact issues promptly. We're happy to credit reporters in the release notes unless you prefer to remain anonymous.
+
+## How the crypto works
+
+For a technical description of client-side AES-GCM, URL-fragment keys, ciphertext formats (v0/v1), PBKDF2 password pastes, and the threat model, see **[docs/SECURITY-MODEL.md](docs/SECURITY-MODEL.md)**.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,8 @@
 
 CloakBin is a **zero-knowledge encrypted pastebin**: encryption happens in the browser and the decryption key lives only in the URL `#fragment`, so the server ever only stores ciphertext. Because privacy is the entire point of the project, we treat any issue that could leak plaintext, keys, or user data — or that weakens the client-side cryptography — as **high priority**.
 
+How the zero-knowledge model is implemented (crypto, storage, burn-after-read, threat model) is documented in **[docs/SECURITY-MODEL.md](docs/SECURITY-MODEL.md)**. This file covers reporting and program scope only.
+
 ## Reporting a Vulnerability
 
 Please report vulnerabilities **privately** — do not open a public issue for a security bug.

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -1,0 +1,184 @@
+# CloakBin Security Model
+
+This document describes **how** CloakBin’s zero-knowledge guarantee works in the current codebase. It is for self-hosters and security-minded contributors who want to verify the claim against the implementation.
+
+For **how to report vulnerabilities**, see [SECURITY.md](../SECURITY.md).
+
+Primary sources:
+
+- Client crypto: [`src/lib/crypto.ts`](../src/lib/crypto.ts)
+- Create paste API: [`src/routes/api/paste/+server.ts`](../src/routes/api/paste/+server.ts)
+- Burn-after-read API: [`src/routes/api/paste/[id]/burn/+server.ts`](../src/routes/api/paste/[id]/burn/+server.ts)
+- Storage adapters (example): [`src/lib/db/adapters/mongodb.ts`](../src/lib/db/adapters/mongodb.ts)
+
+---
+
+## 1. Key generation (browser only)
+
+Random pastes use the Web Crypto API:
+
+```ts
+crypto.subtle.generateKey(
+  { name: 'AES-GCM', length: 256 },
+  true, // extractable so the raw key can be put in the URL fragment
+  ['encrypt', 'decrypt']
+);
+```
+
+- Algorithm: **AES-256-GCM** (authenticated encryption).
+- The key is created in the browser; it is **not** generated on the server.
+- Raw key material is exported with `keyToBase64()` as **base64url** (URL-safe) for the fragment.
+
+Password-protected pastes do **not** use a random key. They derive one with PBKDF2 (see §4).
+
+---
+
+## 2. Why the key lives in the URL fragment
+
+Share links look like:
+
+```text
+https://example.com/p/<paste-id>#<base64url-key>
+```
+
+Browsers **do not send the `#fragment` to the server** on normal navigations and API requests. The fragment is available only to client-side JavaScript on the view page (`base64ToKey`).
+
+Implications:
+
+- The CloakBin server can store and return ciphertext for `paste-id` without ever receiving the decryption key.
+- Anyone who receives the full URL (including the fragment) can decrypt — treat the link like a secret.
+- Referrer leakage, screenshots, browser history, and shoulder-surfing are out of the crypto boundary (see threat model).
+
+---
+
+## 3. Ciphertext formats (v0 vs v1)
+
+All ciphertext is stored as a **base64** string of binary frames.
+
+### v1 (current encrypt path)
+
+Produced by `encrypt()`:
+
+| Bytes | Field |
+|------:|-------|
+| 2 | Magic `CB` (`0x43 0x42`) |
+| 1 | Version `0x01` (gzip-compressed payload) |
+| 12 | AES-GCM IV (`crypto.getRandomValues`) |
+| rest | AES-GCM ciphertext over **gzip** of UTF-8 plaintext (`fflate` gzip level 6) |
+
+On decrypt, if the magic header is present and version is `0x01`, the code slices IV + ciphertext, decrypts, then `gunzipSync`.
+
+### v0 (legacy)
+
+No magic header:
+
+| Bytes | Field |
+|------:|-------|
+| 12 | IV |
+| rest | AES-GCM ciphertext over **uncompressed** UTF-8 plaintext |
+
+`decrypt()` still accepts v0 so old pastes remain readable. New pastes use v1.
+
+Unknown magic versions throw (`Unknown encryption format version`).
+
+---
+
+## 4. Password-protected pastes
+
+Optional password mode:
+
+1. Client generates a random **16-byte salt** (`generateSalt()` → standard base64).
+2. Client derives an AES-256-GCM key with **PBKDF2**:
+   - hash: SHA-256  
+   - iterations: **100_000**  
+   - salt: the bytes above  
+3. Client encrypts as usual (v1 frame).
+4. Client POSTs to the server:
+   - `content`: ciphertext only  
+   - `salt`: the salt (needed to re-derive the key)  
+   - `hasPassword` is implied by presence of salt on create  
+
+The server stores salt **next to** ciphertext so recipients can re-derive the key after entering the password. The password itself never leaves the browser.
+
+---
+
+## 5. What the server stores — and what it never sees
+
+On `POST /api/paste`, the API accepts encrypted `content` plus metadata (`expiry`, optional `salt`, `burnAfterRead`, `language`). It does **not** receive:
+
+- plaintext paste body  
+- AES key material  
+- password  
+
+Typical stored fields (adapters may name columns differently):
+
+| Field | Meaning |
+|-------|---------|
+| `content` | Ciphertext blob (base64 of v0/v1 frame) |
+| `expiresAt` | TTL |
+| `hasPassword` / `salt` | Password mode metadata (salt is not secret by itself) |
+| `burnAfterRead` | One-shot burn flag |
+| `language` | Highlighting id (metadata only; not secret) |
+
+The server can observe metadata (size, timing, IP at the HTTP layer, language tag). Zero-knowledge here means **content confidentiality**, not anonymity or traffic analysis resistance.
+
+---
+
+## 6. Burn-after-read atomicity
+
+Burn is **not** performed on a plain `GET` of the paste. Adapters document that `getPaste` must **not** delete burn-after-read pastes, so the UI can warn the user first.
+
+After the user confirms, the client calls the burn endpoint, which uses `db.burnPaste(id)`.
+
+MongoDB implementation (production path):
+
+```ts
+Model.findOneAndDelete({
+  _id: id,
+  burnAfterRead: true,
+  expiresAt: { $gt: new Date() }
+});
+```
+
+That is a single atomic find-and-delete conditioned on the burn flag and non-expiry. Concurrent burners race on one document; at most one succeeds with the ciphertext payload.
+
+Note: not every storage adapter has a finished `burnPaste` implementation (some still throw `TODO`). Self-hosters should confirm the adapter they deploy implements atomic burn as above.
+
+---
+
+## 7. Threat model
+
+### What CloakBin is designed to protect against
+
+- Server operators or DB dumps reading **plaintext** of pastes.  
+- Passive network observers seeing only ciphertext on the wire (plus TLS if deployed).  
+- Casual forgery of ciphertext without the key (AES-GCM authentication tag fails decrypt).  
+
+### What CloakBin does **not** protect against
+
+- Anyone who has the **full share URL** (id + fragment key), or the password + salt + ciphertext.  
+- Malicious or compromised **client** (XSS, malicious extension, malware).  
+- Endpoint compromise of the **recipient’s** browser or device.  
+- **Metadata** leakage (paste size, timestamps, language, access patterns).  
+- URL leakage via Referer (if a page navigates to a third party with fragment mishandled — prefer careful client routing), chat logs, support tickets, or screenshots.  
+- Weak user passwords in password mode (PBKDF2 helps but does not fix `password123`).  
+- Compromised Web Crypto / browser implementation.  
+
+### Operational recommendations
+
+- Prefer short expiry and burn-after-read for high-sensitivity secrets.  
+- Share the link over a channel you trust; treat `#key` as the secret.  
+- Self-host: keep TLS on, keep dependencies updated, and use an adapter with a real atomic `burnPaste`.  
+- Report crypto or ZK-boundary bugs **privately** via [SECURITY.md](../SECURITY.md).
+
+---
+
+## 8. Quick verification checklist for reviewers
+
+1. `generateKey` / `encrypt` / `decrypt` / PBKDF2 live only in `src/lib/crypto.ts` (browser).  
+2. Create API stores `content` as supplied ciphertext; no server-side encrypt of user plaintext.  
+3. View page reads key from `location.hash` / fragment helpers, not from server JSON.  
+4. Burn uses conditional delete, not “read then later delete” on the hot path.  
+5. Password path sends salt, never the password.
+
+If any of the above regresses, treat it as a high-priority security issue under the project’s disclosure policy.


### PR DESCRIPTION
## Summary
Closes #121.

SECURITY.md covers responsible disclosure but not how encryption works end-to-end. This adds `docs/SECURITY-MODEL.md` mapped to the current implementation.

### Contents
1. Browser key generation (`crypto.subtle.generateKey`, AES-256-GCM)
2. Why the key lives in the URL fragment
3. v0 vs v1 ciphertext (magic `CB`, gzip, IV layout)
4. Password-protected pastes (PBKDF2 100k, salt storage)
5. What the server stores vs never sees
6. Burn-after-read atomicity (`findOneAndDelete` path)
7. Threat model (in / out of scope)

Linked from `README.md` (Security Model section) and `SECURITY.md`.

## Test plan
- [x] Cross-checked against `src/lib/crypto.ts` (AES-GCM, PBKDF2 iterations, v0/v1 frames)
- [x] Cross-checked burn path against Mongo adapter + `api/paste/[id]/burn`
- [x] Links resolve from README and SECURITY.md
- [ ] Maintainer review for accuracy / tone

## Notes
Docs only — no runtime code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive security-model document covering zero-knowledge guarantees, client-side key handling, ciphertext framing (current and legacy), optional password protection, burn-after-read behavior, and the threat model.
  * Updated the README’s “Security Model” section with links to the full architecture write-up and to vulnerability reporting guidance.
  * Expanded SECURITY.md with scope clarification and a “How the crypto works” section that points readers to the detailed cryptography explanation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR is a documentation-only addition — no runtime code changes. It introduces `docs/SECURITY-MODEL.md`, a detailed security model reference cross-verified against the live implementation (`src/lib/crypto.ts`, the MongoDB adapter, and the burn endpoint), and adds cross-reference links from `README.md` and `SECURITY.md`.

- **`docs/SECURITY-MODEL.md`**: New doc covering AES-256-GCM key generation, URL-fragment key design, v0/v1 ciphertext layouts, PBKDF2 password pastes, server-stored fields, burn-after-read atomicity, and a threat model. The crypto descriptions are accurate against the code; however, Section 2's URL format example does not note that password-protected pastes carry no key in the fragment.
- **`SECURITY.md`**: Adds two cross-references to the new doc, creating minor redundancy.
- **`README.md`**: Adds a single line linking to both new and existing security docs.
</details>

<h3>Confidence Score: 4/5</h3>

Docs-only PR; no runtime code is touched, so merging cannot break anything.

The new SECURITY-MODEL.md is well-researched and matches the implementation in almost every detail. Section 2 presents the fragment-key URL pattern as universal without noting that password-protected pastes have no key fragment — for a document meant to be the authoritative security reference this is worth fixing before it misleads future security reviewers or self-hosters.

docs/SECURITY-MODEL.md — Section 2 URL example and the stored-fields table both warrant a small correction before this becomes the canonical security reference.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/SECURITY-MODEL.md | New security model doc — most claims verified against the implementation. Section 2 URL example omits the password-paste caveat; stored-fields table omits createdAt. |
| SECURITY.md | Adds two cross-references to SECURITY-MODEL.md; both accurate but the bottom section is redundant. |
| README.md | Adds a single accurate link line. No issues. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Adocs%2FSECURITY-MODEL.md%3A43-54%0A**URL%20fragment%20example%20misleads%20on%20password-protected%20pastes**%0A%0ASection%202%20presents%20%60https%3A%2F%2Fexample.com%2Fp%2F%3Cpaste-id%3E%23%3Cbase64url-key%3E%60%20as%20the%20universal%20share%20link%20format%2C%20but%20password-protected%20pastes%20derive%20their%20key%20from%20PBKDF2%20and%20never%20place%20a%20key%20in%20the%20URL%20fragment%20%E2%80%94%20the%20fragment%20is%20absent%20or%20empty.%20A%20reader%20anchoring%20their%20mental%20model%20on%20Section%202%20alone%20would%20incorrectly%20assume%20all%20paste%20links%20carry%20%60%23key%60.%20The%20URL%20example%20should%20add%20a%20parenthetical%20like%20%22%28random-key%20pastes%20only%3B%20password-protected%20pastes%20use%20no%20fragment%20key%29%22%20or%20a%20short%20follow-up%20sentence.%0A%0A%23%23%23%20Issue%202%20of%203%0ASECURITY.md%3A36-38%0AThe%20new%20%22%23%23%20How%20the%20crypto%20works%22%20section%20duplicates%20the%20inline%20cross-reference%20already%20added%20on%20line%205%20of%20the%20same%20file.%20Having%20two%20identical%20links%20in%20the%20same%20short%20document%20adds%20noise%3B%20consider%20removing%20one.%0A%0A%60%60%60suggestion%0A%3C!--%20Crypto%20details%20are%20covered%20by%20the%20inline%20link%20in%20the%20preamble%20above.%20--%3E%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2FSECURITY-MODEL.md%3A115-121%0AThe%20stored-fields%20table%20omits%20%60createdAt%60%2C%20which%20the%20MongoDB%20adapter%20persists%20%28schema%20line%2037%29.%20The%20section%20mentions%20%22timing%22%20as%20server-observable%20metadata%2C%20but%20listing%20the%20concrete%20field%20makes%20the%20table%20a%20complete%20inventory.%0A%0A%60%60%60suggestion%0A%7C%20Field%20%7C%20Meaning%20%7C%0A%7C-------%7C---------%7C%0A%7C%20%60content%60%20%7C%20Ciphertext%20blob%20%28base64%20of%20v0%2Fv1%20frame%29%20%7C%0A%7C%20%60createdAt%60%20%7C%20Creation%20timestamp%20%28server-observable%20metadata%29%20%7C%0A%7C%20%60expiresAt%60%20%7C%20TTL%20%7C%0A%7C%20%60hasPassword%60%20%2F%20%60salt%60%20%7C%20Password%20mode%20metadata%20%28salt%20is%20not%20secret%20by%20itself%29%20%7C%0A%7C%20%60burnAfterRead%60%20%7C%20One-shot%20burn%20flag%20%7C%0A%7C%20%60language%60%20%7C%20Highlighting%20id%20%28metadata%20only%3B%20not%20secret%29%20%7C%0A%60%60%60%0A%0A&repo=ishannaik%2Fcloakbin&pr=158&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22docs%2F121-security-model%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2F121-security-model%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Adocs%2FSECURITY-MODEL.md%3A43-54%0A**URL%20fragment%20example%20misleads%20on%20password-protected%20pastes**%0A%0ASection%202%20presents%20%60https%3A%2F%2Fexample.com%2Fp%2F%3Cpaste-id%3E%23%3Cbase64url-key%3E%60%20as%20the%20universal%20share%20link%20format%2C%20but%20password-protected%20pastes%20derive%20their%20key%20from%20PBKDF2%20and%20never%20place%20a%20key%20in%20the%20URL%20fragment%20%E2%80%94%20the%20fragment%20is%20absent%20or%20empty.%20A%20reader%20anchoring%20their%20mental%20model%20on%20Section%202%20alone%20would%20incorrectly%20assume%20all%20paste%20links%20carry%20%60%23key%60.%20The%20URL%20example%20should%20add%20a%20parenthetical%20like%20%22%28random-key%20pastes%20only%3B%20password-protected%20pastes%20use%20no%20fragment%20key%29%22%20or%20a%20short%20follow-up%20sentence.%0A%0A%23%23%23%20Issue%202%20of%203%0ASECURITY.md%3A36-38%0AThe%20new%20%22%23%23%20How%20the%20crypto%20works%22%20section%20duplicates%20the%20inline%20cross-reference%20already%20added%20on%20line%205%20of%20the%20same%20file.%20Having%20two%20identical%20links%20in%20the%20same%20short%20document%20adds%20noise%3B%20consider%20removing%20one.%0A%0A%60%60%60suggestion%0A%3C!--%20Crypto%20details%20are%20covered%20by%20the%20inline%20link%20in%20the%20preamble%20above.%20--%3E%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2FSECURITY-MODEL.md%3A115-121%0AThe%20stored-fields%20table%20omits%20%60createdAt%60%2C%20which%20the%20MongoDB%20adapter%20persists%20%28schema%20line%2037%29.%20The%20section%20mentions%20%22timing%22%20as%20server-observable%20metadata%2C%20but%20listing%20the%20concrete%20field%20makes%20the%20table%20a%20complete%20inventory.%0A%0A%60%60%60suggestion%0A%7C%20Field%20%7C%20Meaning%20%7C%0A%7C-------%7C---------%7C%0A%7C%20%60content%60%20%7C%20Ciphertext%20blob%20%28base64%20of%20v0%2Fv1%20frame%29%20%7C%0A%7C%20%60createdAt%60%20%7C%20Creation%20timestamp%20%28server-observable%20metadata%29%20%7C%0A%7C%20%60expiresAt%60%20%7C%20TTL%20%7C%0A%7C%20%60hasPassword%60%20%2F%20%60salt%60%20%7C%20Password%20mode%20metadata%20%28salt%20is%20not%20secret%20by%20itself%29%20%7C%0A%7C%20%60burnAfterRead%60%20%7C%20One-shot%20burn%20flag%20%7C%0A%7C%20%60language%60%20%7C%20Highlighting%20id%20%28metadata%20only%3B%20not%20secret%29%20%7C%0A%60%60%60%0A%0A&repo=ishannaik%2Fcloakbin&pr=158&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Adocs%2FSECURITY-MODEL.md%3A43-54%0A**URL%20fragment%20example%20misleads%20on%20password-protected%20pastes**%0A%0ASection%202%20presents%20%60https%3A%2F%2Fexample.com%2Fp%2F%3Cpaste-id%3E%23%3Cbase64url-key%3E%60%20as%20the%20universal%20share%20link%20format%2C%20but%20password-protected%20pastes%20derive%20their%20key%20from%20PBKDF2%20and%20never%20place%20a%20key%20in%20the%20URL%20fragment%20%E2%80%94%20the%20fragment%20is%20absent%20or%20empty.%20A%20reader%20anchoring%20their%20mental%20model%20on%20Section%202%20alone%20would%20incorrectly%20assume%20all%20paste%20links%20carry%20%60%23key%60.%20The%20URL%20example%20should%20add%20a%20parenthetical%20like%20%22%28random-key%20pastes%20only%3B%20password-protected%20pastes%20use%20no%20fragment%20key%29%22%20or%20a%20short%20follow-up%20sentence.%0A%0A%23%23%23%20Issue%202%20of%203%0ASECURITY.md%3A36-38%0AThe%20new%20%22%23%23%20How%20the%20crypto%20works%22%20section%20duplicates%20the%20inline%20cross-reference%20already%20added%20on%20line%205%20of%20the%20same%20file.%20Having%20two%20identical%20links%20in%20the%20same%20short%20document%20adds%20noise%3B%20consider%20removing%20one.%0A%0A%60%60%60suggestion%0A%3C!--%20Crypto%20details%20are%20covered%20by%20the%20inline%20link%20in%20the%20preamble%20above.%20--%3E%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2FSECURITY-MODEL.md%3A115-121%0AThe%20stored-fields%20table%20omits%20%60createdAt%60%2C%20which%20the%20MongoDB%20adapter%20persists%20%28schema%20line%2037%29.%20The%20section%20mentions%20%22timing%22%20as%20server-observable%20metadata%2C%20but%20listing%20the%20concrete%20field%20makes%20the%20table%20a%20complete%20inventory.%0A%0A%60%60%60suggestion%0A%7C%20Field%20%7C%20Meaning%20%7C%0A%7C-------%7C---------%7C%0A%7C%20%60content%60%20%7C%20Ciphertext%20blob%20%28base64%20of%20v0%2Fv1%20frame%29%20%7C%0A%7C%20%60createdAt%60%20%7C%20Creation%20timestamp%20%28server-observable%20metadata%29%20%7C%0A%7C%20%60expiresAt%60%20%7C%20TTL%20%7C%0A%7C%20%60hasPassword%60%20%2F%20%60salt%60%20%7C%20Password%20mode%20metadata%20%28salt%20is%20not%20secret%20by%20itself%29%20%7C%0A%7C%20%60burnAfterRead%60%20%7C%20One-shot%20burn%20flag%20%7C%0A%7C%20%60language%60%20%7C%20Highlighting%20id%20%28metadata%20only%3B%20not%20secret%29%20%7C%0A%60%60%60%0A%0A&pr=158&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
docs/SECURITY-MODEL.md:43-54
**URL fragment example misleads on password-protected pastes**

Section 2 presents `https://example.com/p/<paste-id>#<base64url-key>` as the universal share link format, but password-protected pastes derive their key from PBKDF2 and never place a key in the URL fragment — the fragment is absent or empty. A reader anchoring their mental model on Section 2 alone would incorrectly assume all paste links carry `#key`. The URL example should add a parenthetical like "(random-key pastes only; password-protected pastes use no fragment key)" or a short follow-up sentence.

### Issue 2 of 3
SECURITY.md:36-38
The new "## How the crypto works" section duplicates the inline cross-reference already added on line 5 of the same file. Having two identical links in the same short document adds noise; consider removing one.

```suggestion
<!-- Crypto details are covered by the inline link in the preamble above. -->
```

### Issue 3 of 3
docs/SECURITY-MODEL.md:115-121
The stored-fields table omits `createdAt`, which the MongoDB adapter persists (schema line 37). The section mentions "timing" as server-observable metadata, but listing the concrete field makes the table a complete inventory.

```suggestion
| Field | Meaning |
|-------|---------|
| `content` | Ciphertext blob (base64 of v0/v1 frame) |
| `createdAt` | Creation timestamp (server-observable metadata) |
| `expiresAt` | TTL |
| `hasPassword` / `salt` | Password mode metadata (salt is not secret by itself) |
| `burnAfterRead` | One-shot burn flag |
| `language` | Highlighting id (metadata only; not secret) |
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(security): add SECURITY-MODEL.md fo..."](https://github.com/ishannaik/cloakbin/commit/b269446685251bfd46cfe8fca3e23d4c1506ce5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46230620)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->