### PR TITLE
fix(security): remove deprecated X-XSS-Protection header

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -254,11 +254,6 @@ export const handle: Handle = async ({ event, resolve }) => {
 		'camera=(), microphone=(), geolocation=(), interest-cohort=()'
 	);
 
-	// 5. X-XSS-Protection: Legacy XSS filter (for older browsers)
-	// Modern browsers have better protection, but this helps older ones
-	// 1; mode=block = enable filter and block the page if attack detected
-	response.headers.set('X-XSS-Protection', '1; mode=block');
-
 	// 6. X-DNS-Prefetch-Control: Control DNS prefetching
 	// Browsers sometimes pre-resolve DNS for links on the page
 	// 'off' = disable this (minor privacy improvement)
@@ -276,6 +271,10 @@ export const handle: Handle = async ({ event, resolve }) => {
 	}
 
 	// 8. Content-Security-Policy (CSP): Control what resources can load
+	// AUDIT (issue #81): `unsafe-eval` is still present. Removing it breaks
+	// SvelteKit's client runtime / HMR in development; production builds may
+	// still rely on it depending on adapters. Do not drop without a full
+	// smoke test of create/view/burn paste + CLI upload flows.
 	// This is the most powerful security header - defines allowed sources
 	// - default-src 'self' = only load resources from your own domain
 	// - script-src 'self' 'unsafe-inline' = scripts from self + inline scripts (needed for Svelte)
@@ -287,7 +286,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 		'Content-Security-Policy',
 		[
 			"default-src 'self'",
-			"script-src 'self' 'unsafe-inline' 'unsafe-eval'", // unsafe-eval needed for some Svelte features
+			"script-src 'self' 'unsafe-inline' 'unsafe-eval'", // retained: SvelteKit/Vite client needs eval in dev; see comment above
 			"style-src 'self' 'unsafe-inline'",
 			"img-src 'self' data: blob:",
 			"font-src 'self' data:",


### PR DESCRIPTION
## Summary
Closes #81.

### Done
- Removed `X-XSS-Protection: 1; mode=block` from `src/hooks.server.ts`
- Documented CSP `unsafe-eval` audit: still required for SvelteKit/Vite client (esp. dev/HMR); not dropped in this PR

### Why
`X-XSS-Protection` is deprecated. Modern browsers ignore it; older ones can misbehave. Removal is the recommended default.

## Test plan
- [x] Source no longer sets `X-XSS-Protection`
- [ ] Maintainer: smoke create/view paste pages after deploy

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the deprecated `X-XSS-Protection: 1; mode=block` header from `src/hooks.server.ts` and adds an inline audit comment explaining why `unsafe-eval` is retained in the CSP `script-src` directive.

- **Header removal**: `X-XSS-Protection` is deprecated; modern browsers ignore it and some older browsers can behave unexpectedly with it set. The removal is the correct, standards-recommended approach.
- **CSP audit note**: The PR adds a comment (referencing issue #81) documenting that `unsafe-eval` is intentionally kept because SvelteKit/Vite's client runtime and HMR require it; no functional change is made to the CSP directive itself.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — removes a deprecated header with no functional replacement needed, and makes no changes to any active security logic.

The change is a single-line deletion of a header that modern browsers already ignore. The added audit comment is documentation-only and introduces no behavioral changes. The rest of the security header stack (CSP, HSTS, COOP, CORP, etc.) is untouched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/hooks.server.ts | Removes deprecated X-XSS-Protection header and adds an explanatory audit comment for the retained unsafe-eval CSP directive; comment numbering now skips 5. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B[SvelteKit Handle Hook]
    B --> C[Resolve Response]
    C --> D[Set X-Frame-Options: DENY]
    D --> E[Set X-Content-Type-Options: nosniff]
    E --> F[Set Referrer-Policy]
    F --> G[Set Permissions-Policy]
    G --> H["❌ REMOVED: X-XSS-Protection: 1; mode=block\n(deprecated header)"]
    H --> I[Set X-DNS-Prefetch-Control: off]
    I --> J{Is production?}
    J -- Yes --> K[Set HSTS]
    J -- No --> L[Skip HSTS]
    K --> M["Set CSP\nscript-src includes unsafe-eval\nsee audit comment #81"]
    L --> M
    M --> N[Set Cache-Control for /p/ and /r/ routes]
    N --> O[Set COOP / CORP]
    O --> P[Return Response]

    style H fill:#ffcccc,stroke:#cc0000
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fhooks.server.ts%3A257%0AAfter%20removing%20the%20%60X-XSS-Protection%60%20block%20%28which%20was%20numbered%205%29%2C%20the%20comment%20sequence%20jumps%20straight%20from%204%20to%206%2C%20leaving%20a%20gap%20in%20the%20ordering.%0A%0A%60%60%60suggestion%0A%09%2F%2F%205.%20X-DNS-Prefetch-Control%3A%20Control%20DNS%20prefetching%0A%60%60%60%0A%0A&repo=ishannaik%2Fcloakbin&pr=159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22fix%2F81-remove-x-xss-protection%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F81-remove-x-xss-protection%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fhooks.server.ts%3A257%0AAfter%20removing%20the%20%60X-XSS-Protection%60%20block%20%28which%20was%20numbered%205%29%2C%20the%20comment%20sequence%20jumps%20straight%20from%204%20to%206%2C%20leaving%20a%20gap%20in%20the%20ordering.%0A%0A%60%60%60suggestion%0A%09%2F%2F%205.%20X-DNS-Prefetch-Control%3A%20Control%20DNS%20prefetching%0A%60%60%60%0A%0A&repo=ishannaik%2Fcloakbin&pr=159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fhooks.server.ts%3A257%0AAfter%20removing%20the%20%60X-XSS-Protection%60%20block%20%28which%20was%20numbered%205%29%2C%20the%20comment%20sequence%20jumps%20straight%20from%204%20to%206%2C%20leaving%20a%20gap%20in%20the%20ordering.%0A%0A%60%60%60suggestion%0A%09%2F%2F%205.%20X-DNS-Prefetch-Control%3A%20Control%20DNS%20prefetching%0A%60%60%60%0A%0A&pr=159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/hooks.server.ts:257
After removing the `X-XSS-Protection` block (which was numbered 5), the comment sequence jumps straight from 4 to 6, leaving a gap in the ordering.

```suggestion
	// 5. X-DNS-Prefetch-Control: Control DNS prefetching
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): remove deprecated X-XSS-P..."](https://github.com/ishannaik/cloakbin/commit/ba57c5f1cdc3f3a16804b54c868d1e9a0a5ea541) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46231440)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Removed the legacy `X-XSS-Protection` browser security header.
  * Updated Content Security Policy documentation to clarify required runtime settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->