### PR TITLE
fix(security): env-driven MAX_PASTE_BYTES size limit (default 10 MiB)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
-MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/?retryWrites=true&w=majority
+MONGODB_URI=mongodb+srv://username:***@cluster.mongodb.net/?retryWrites=true&w=majority
 
 # Admin Panel
 ADMIN_USER=admin
 ADMIN_PASS=changeme
+
+# Max paste ciphertext size in bytes (UTF-8). Default: 10485760 (10 MiB).
+# Self-hosters: lower this to reduce DoS risk. Invalid values fall back to the default.
+# MAX_PASTE_BYTES=10485760

--- a/src/lib/server/maxPasteBytes.test.ts
+++ b/src/lib/server/maxPasteBytes.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import {
+	resolveMaxPasteBytes,
+	utf8ByteLength,
+	DEFAULT_MAX_PASTE_BYTES
+} from './maxPasteBytes';
+
+describe('resolveMaxPasteBytes', () => {
+	it('defaults to 10 MiB when unset or empty', () => {
+		expect(resolveMaxPasteBytes(undefined)).toBe(DEFAULT_MAX_PASTE_BYTES);
+		expect(resolveMaxPasteBytes('')).toBe(DEFAULT_MAX_PASTE_BYTES);
+		expect(DEFAULT_MAX_PASTE_BYTES).toBe(10 * 1024 * 1024);
+	});
+
+	it('parses a positive integer env value', () => {
+		expect(resolveMaxPasteBytes('1048576')).toBe(1_048_576);
+		expect(resolveMaxPasteBytes('100')).toBe(100);
+	});
+
+	it('falls back on invalid or non-positive values', () => {
+		expect(resolveMaxPasteBytes('nope')).toBe(DEFAULT_MAX_PASTE_BYTES);
+		expect(resolveMaxPasteBytes('0')).toBe(DEFAULT_MAX_PASTE_BYTES);
+		expect(resolveMaxPasteBytes('-5')).toBe(DEFAULT_MAX_PASTE_BYTES);
+		expect(resolveMaxPasteBytes('1.5')).toBe(1); // parseInt truncates
+	});
+});
+
+describe('utf8ByteLength', () => {
+	it('counts ASCII one byte per char', () => {
+		expect(utf8ByteLength('abc')).toBe(3);
+	});
+
+	it('counts multi-byte UTF-8 correctly', () => {
+		expect(utf8ByteLength('é')).toBe(2);
+		expect(utf8ByteLength('🙂')).toBe(4);
+	});
+});

--- a/src/lib/server/maxPasteBytes.ts
+++ b/src/lib/server/maxPasteBytes.ts
@@ -1,0 +1,20 @@
+/**
+ * Resolve max paste size from env (DoS control for self-hosters).
+ *
+ * `MAX_PASTE_BYTES` — maximum UTF-8 byte length of the ciphertext string.
+ * Default: 10 MiB. Invalid / non-positive values fall back to the default.
+ */
+export const DEFAULT_MAX_PASTE_BYTES = 10 * 1024 * 1024; // 10 MiB
+
+export function resolveMaxPasteBytes(
+	raw: string | undefined = typeof process !== 'undefined' ? process.env.MAX_PASTE_BYTES : undefined
+): number {
+	if (raw === undefined || raw === '') return DEFAULT_MAX_PASTE_BYTES;
+	const n = Number.parseInt(String(raw), 10);
+	return Number.isFinite(n) && n > 0 ? n : DEFAULT_MAX_PASTE_BYTES;
+}
+
+/** UTF-8 byte length of a JS string (paste ciphertext). */
+export function utf8ByteLength(value: string): number {
+	return new TextEncoder().encode(value).byteLength;
+}

--- a/src/routes/api/paste/+server.ts
+++ b/src/routes/api/paste/+server.ts
@@ -16,9 +16,12 @@
 
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { env } from '$env/dynamic/private';
 import { db } from '$lib/db';
+import { resolveMaxPasteBytes, utf8ByteLength } from '$lib/server/maxPasteBytes';
 
-const MAX_CONTENT_SIZE = 100_000_000; // 100MB in characters
+/** Max UTF-8 bytes for paste content; override with MAX_PASTE_BYTES (default 10 MiB). */
+const MAX_PASTE_BYTES = resolveMaxPasteBytes(env.MAX_PASTE_BYTES);
 
 const EXPIRY_DURATIONS = {
 	'1h': 60 * 60 * 1000,           // 1 hour in ms
@@ -66,10 +69,10 @@ export const POST: RequestHandler = async ({ request }) => {
 			);
 		}
 
-		if (content.length > MAX_CONTENT_SIZE) {
+		if (utf8ByteLength(content) > MAX_PASTE_BYTES) {
 			return json(
-				{ error: `Content exceeds maximum size of ${MAX_CONTENT_SIZE} characters` },
-				{ status: 400 }
+				{ error: `Content exceeds maximum size of ${MAX_PASTE_BYTES} bytes` },
+				{ status: 413 }
 			);
 		}
 


### PR DESCRIPTION
## Summary
Closes #79.

Hard-coded `MAX_CONTENT_SIZE = 100_000_000` characters is a large self-host DoS default. This PR makes the limit env-driven.

### Changes
- `src/lib/server/maxPasteBytes.ts` — `resolveMaxPasteBytes()` + `utf8ByteLength()`
- `src/routes/api/paste/+server.ts` — enforce UTF-8 byte limit; **413** when over size
- Default: **10 MiB** (`10485760`)
- Override: `MAX_PASTE_BYTES` (invalid/non-positive → default)
- `.env.example` documented
- Unit tests: `src/lib/server/maxPasteBytes.test.ts`

## Test plan
- [x] `vitest run src/lib/server/maxPasteBytes.test.ts` → **5 passed**
- [ ] Maintainer: `MAX_PASTE_BYTES=100` rejects larger ciphertext with 413
- [ ] Maintainer: unset env accepts normal pastes under 10 MiB

## Notes
One issue per PR. Independent of #132 language allowlist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced paste size limits using UTF-8 byte length (instead of character count).
  * Added a default 10 MiB maximum with optional configuration via `MAX_PASTE_BYTES`.
  * Oversized pastes now return HTTP `413` indicating the maximum allowed size in bytes.
* **Documentation**
  * Updated `.env.example` to redact the database password and added guidance for `MAX_PASTE_BYTES` (10 MiB default).
* **Tests**
  * Added tests for defaulting, parsing invalid/edge values, and UTF-8 byte length for multibyte content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces a hard-coded 100 MB character limit with an env-driven UTF-8 byte limit (`MAX_PASTE_BYTES`, default 10 MiB) and returns HTTP 413 on oversized pastes.

- **`maxPasteBytes.ts`** — new helper that reads and validates the env var, with `utf8ByteLength` using `TextEncoder` for correct multi-byte counting.
- **`+server.ts`** — swaps `content.length` for `utf8ByteLength(content)` and upgrades the status code from 400 to 413; the check applies only to `content`, leaving `salt` and other body fields unbounded.
- **`.env.example`** — documents the new variable and redacts the sample DB password.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the unbounded `salt` field, which lets an attacker bypass the new content size gate entirely.

The `content` field is correctly capped, but `salt` (and `language`) are accepted without any size constraint on the same POST path. A crafted request with a 1-byte `content` and a multi-gigabyte `salt` passes the new guard, materialises fully in heap, and is forwarded to MongoDB unchanged. The core helper logic and env-resolution are sound; only the enforcement scope in the route needs to be widened.

`src/routes/api/paste/+server.ts` — the size check covers `content` only; `salt` needs a parallel bound.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/server/maxPasteBytes.ts | New module exposing `resolveMaxPasteBytes` and `utf8ByteLength`; logic is correct for the `content` field it is designed to guard. |
| src/lib/server/maxPasteBytes.test.ts | Unit tests cover default, valid integers, fallback cases, and multi-byte UTF-8; good coverage of the helper functions. |
| src/routes/api/paste/+server.ts | Enforces the new byte limit correctly for `content`, but leaves `salt` and `language` fields unbounded — a crafted request can bypass the limit entirely by embedding the payload in `salt`. |
| .env.example | Documents the new `MAX_PASTE_BYTES` variable and redacts the example DB password; no issues. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Server as POST /api/paste
    participant Limit as resolveMaxPasteBytes
    participant DB as MongoDB

    Client->>Server: POST /api/paste (full JSON body)
    Note over Server: request.json() buffers entire body
    Server->>Server: "validate content type & non-empty"
    Server->>Limit: "utf8ByteLength(content) > MAX_PASTE_BYTES?"
    alt content exceeds limit
        Server-->>Client: 413 Content Too Large
    else content within limit
        Note over Server: ⚠️ salt / language unchecked
        Server->>DB: "createPaste({ content, salt, ... })"
        DB-->>Server: "{ id }"
        Server-->>Client: "201 { id }"
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Froutes%2Fapi%2Fpaste%2F%2Bserver.ts%3A73-78%0A**%60salt%60%20field%20is%20unbounded%2C%20bypassing%20the%20size%20limit**%0A%0AThe%20size%20guard%20checks%20only%20%60content%60%2C%20but%20the%20%60salt%60%20field%20%28and%20%60language%60%29%20are%20accepted%20without%20any%20length%20constraint.%20An%20attacker%20can%20craft%20a%20request%20with%20a%20tiny%20%60content%60%20and%20a%20multi-gigabyte%20%60salt%60%2C%20which%20passes%20the%20new%20check%2C%20fully%20materialises%20in%20heap%2C%20and%20gets%20written%20to%20the%20database.%20A%20concrete%20bypass%3A%20%60%7B%22content%22%3A%22x%22%2C%22expiry%22%3A%221h%22%2C%22salt%22%3A%22%3C1%20GB%20padding%3E%22%7D%60%20sets%20%60utf8ByteLength%28content%29%20%3D%201%60%2C%20skips%20the%20guard%20entirely%2C%20and%20stores%20the%20oversized%20%60salt%60%20in%20MongoDB.%0A%0A&repo=ishannaik%2Fcloakbin&pr=160&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22fix%2F79-max-paste-bytes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F79-max-paste-bytes%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Froutes%2Fapi%2Fpaste%2F%2Bserver.ts%3A73-78%0A**%60salt%60%20field%20is%20unbounded%2C%20bypassing%20the%20size%20limit**%0A%0AThe%20size%20guard%20checks%20only%20%60content%60%2C%20but%20the%20%60salt%60%20field%20%28and%20%60language%60%29%20are%20accepted%20without%20any%20length%20constraint.%20An%20attacker%20can%20craft%20a%20request%20with%20a%20tiny%20%60content%60%20and%20a%20multi-gigabyte%20%60salt%60%2C%20which%20passes%20the%20new%20check%2C%20fully%20materialises%20in%20heap%2C%20and%20gets%20written%20to%20the%20database.%20A%20concrete%20bypass%3A%20%60%7B%22content%22%3A%22x%22%2C%22expiry%22%3A%221h%22%2C%22salt%22%3A%22%3C1%20GB%20padding%3E%22%7D%60%20sets%20%60utf8ByteLength%28content%29%20%3D%201%60%2C%20skips%20the%20guard%20entirely%2C%20and%20stores%20the%20oversized%20%60salt%60%20in%20MongoDB.%0A%0A&repo=ishannaik%2Fcloakbin&pr=160&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Froutes%2Fapi%2Fpaste%2F%2Bserver.ts%3A73-78%0A**%60salt%60%20field%20is%20unbounded%2C%20bypassing%20the%20size%20limit**%0A%0AThe%20size%20guard%20checks%20only%20%60content%60%2C%20but%20the%20%60salt%60%20field%20%28and%20%60language%60%29%20are%20accepted%20without%20any%20length%20constraint.%20An%20attacker%20can%20craft%20a%20request%20with%20a%20tiny%20%60content%60%20and%20a%20multi-gigabyte%20%60salt%60%2C%20which%20passes%20the%20new%20check%2C%20fully%20materialises%20in%20heap%2C%20and%20gets%20written%20to%20the%20database.%20A%20concrete%20bypass%3A%20%60%7B%22content%22%3A%22x%22%2C%22expiry%22%3A%221h%22%2C%22salt%22%3A%22%3C1%20GB%20padding%3E%22%7D%60%20sets%20%60utf8ByteLength%28content%29%20%3D%201%60%2C%20skips%20the%20guard%20entirely%2C%20and%20stores%20the%20oversized%20%60salt%60%20in%20MongoDB.%0A%0A&pr=160&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/routes/api/paste/+server.ts:73-78
**`salt` field is unbounded, bypassing the size limit**

The size guard checks only `content`, but the `salt` field (and `language`) are accepted without any length constraint. An attacker can craft a request with a tiny `content` and a multi-gigabyte `salt`, which passes the new check, fully materialises in heap, and gets written to the database. A concrete bypass: `{"content":"x","expiry":"1h","salt":"<1 GB padding>"}` sets `utf8ByteLength(content) = 1`, skips the guard entirely, and stores the oversized `salt` in MongoDB.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["merge: resolve #160 with main after lang..."](https://github.com/ishannaik/cloakbin/commit/3cd58bec1f7667fa8de452898414bbb130ab4f1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46231951)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->