### PR TITLE
docs(security): address post-merge SECURITY-MODEL nits from #158

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,7 +32,3 @@ Security fixes are applied to the latest `main` branch and the most recent tagge
 ## Response
 
 We aim to acknowledge a valid report within a few days and to address confirmed high-impact issues promptly. We're happy to credit reporters in the release notes unless you prefer to remain anonymous.
-
-## How the crypto works
-
-For a technical description of client-side AES-GCM, URL-fragment keys, ciphertext formats (v0/v1), PBKDF2 password pastes, and the threat model, see **[docs/SECURITY-MODEL.md](docs/SECURITY-MODEL.md)**.

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -35,7 +35,7 @@ Password-protected pastes do **not** use a random key. They derive one with PBKD
 
 ## 2. Why the key lives in the URL fragment
 
-Share links look like:
+**Random (non-password) pastes** share links like:
 
 ```text
 https://example.com/p/<paste-id>#<base64url-key>
@@ -43,10 +43,12 @@ https://example.com/p/<paste-id>#<base64url-key>
 
 Browsers **do not send the `#fragment` to the server** on normal navigations and API requests. The fragment is available only to client-side JavaScript on the view page (`base64ToKey`).
 
+**Password-protected pastes do not put a key in `#`.** The share URL is only `…/p/<paste-id>` (no fragment). Recipients type the password in the browser; the client re-derives the AES key with PBKDF2 from that password plus the server-stored salt (see §4). The create UI already states this; do not assume every paste URL carries `#key`.
+
 Implications:
 
-- The CloakBin server can store and return ciphertext for `paste-id` without ever receiving the decryption key.
-- Anyone who receives the full URL (including the fragment) can decrypt — treat the link like a secret.
+- The CloakBin server can store and return ciphertext for `paste-id` without ever receiving the decryption key (or the password).
+- Anyone who receives a full random-paste URL (including the fragment) can decrypt — treat that link like a secret.
 - Referrer leakage, screenshots, browser history, and shoulder-surfing are out of the crypto boundary (see threat model).
 
 ---
@@ -115,6 +117,7 @@ Typical stored fields (adapters may name columns differently):
 | Field | Meaning |
 |-------|---------|
 | `content` | Ciphertext blob (base64 of v0/v1 frame) |
+| `createdAt` | Creation timestamp |
 | `expiresAt` | TTL |
 | `hasPassword` / `salt` | Password mode metadata (salt is not secret by itself) |
 | `burnAfterRead` | One-shot burn flag |


### PR DESCRIPTION
## Summary
Follow-up to the merged security pack (#157–#160), addressing maintainer notes on #158:

1. **§2** — password-protected pastes do **not** put a key in `#`; only random pastes use the fragment.
2. **Stored fields table** — add `createdAt`.
3. **SECURITY.md** — drop the second “How the crypto works” block (the intro already links `docs/SECURITY-MODEL.md`).

## Test plan
- [x] Docs-only; no code/runtime change
- [ ] Maintainer skim of §2 + table + SECURITY.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on expected response timelines and reporter credit for confirmed high-impact security reports.
  * Clarified how sharing links and decryption keys work for random and password-protected pastes.
  * Documented that stored records include a creation timestamp.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This is a docs-only follow-up to the security pack in PRs #157–#160, addressing three maintainer nits on #158.

- **§2 of `SECURITY-MODEL.md`** is updated to clarify that only random (non-password) pastes carry a `#fragment` key in the share URL; a new paragraph accurately explains that password-protected pastes use PBKDF2 derivation with no fragment. The implications bullets are tightened to match.
- **Stored-fields table** gains a `createdAt` row.
- **`SECURITY.md`** drops the redundant \"How the crypto works\" section, since the intro already links `docs/SECURITY-MODEL.md`.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are documentation only with no runtime impact.

The SECURITY-MODEL.md edits are technically accurate and well-scoped. The one remaining rough edge is that SECURITY.md's opening paragraph still describes the decryption key as living only in the URL fragment, which contradicts the password-paste clarification this very PR introduces. A vulnerability reporter whose first stop is SECURITY.md may scope their research incorrectly before reaching the model doc.

SECURITY.md — the introductory paragraph needs a small update to reflect that password-protected pastes derive their key via PBKDF2 with no fragment in the share URL.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| SECURITY.md | Removes the redundant 'How the crypto works' block; intro link to SECURITY-MODEL.md is sufficient. Intro paragraph still describes the key as living only in `#fragment`, which is inaccurate for password-protected pastes. |
| docs/SECURITY-MODEL.md | §2 correctly scopes the fragment-URL pattern to random pastes and adds an accurate paragraph explaining password-paste behavior; `createdAt` row added to the stored-fields table. Content is technically accurate against §1 and §4. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User creates paste] --> B{Password protected?}
    B -- No --> C[Browser generates random AES-256-GCM key]
    C --> D[Encrypt content with key]
    D --> E[POST ciphertext to server]
    E --> F[Server stores ciphertext only]
    F --> G[Share URL: /p/id#base64url-key]
    B -- Yes --> H[Browser generates random 16-byte salt]
    H --> I[Derive AES key via PBKDF2 SHA-256 100k iterations]
    I --> J[Encrypt content with derived key]
    J --> K[POST ciphertext + salt to server]
    K --> L[Server stores ciphertext + salt]
    L --> M[Share URL: /p/id — no fragment]
    G --> N[Recipient: key read from #fragment by client JS]
    M --> O[Recipient: types password → client re-derives key with PBKDF2 + salt]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `SECURITY.md`, line 3 ([link](https://github.com/ishannaik/cloakbin/blob/7e68050a5583e2f3b51a8538f08c5e8852d5de9a/SECURITY.md#L3)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Intro still overgeneralises key location to `#fragment`**

   The opening paragraph states "the decryption key lives only in the URL `#fragment`", but this PR's whole purpose is to document that password-protected pastes have no fragment at all — the AES key is PBKDF2-derived in the browser and never placed in the URL. A reader whose first stop is `SECURITY.md` (e.g. a vulnerability reporter scoping their research) will leave with a false understanding of the threat model before they ever reach `SECURITY-MODEL.md §2`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: SECURITY.md
   Line: 3

   Comment:
   **Intro still overgeneralises key location to `#fragment`**

   The opening paragraph states "the decryption key lives only in the URL `#fragment`", but this PR's whole purpose is to document that password-protected pastes have no fragment at all — the AES key is PBKDF2-derived in the browser and never placed in the URL. A reader whose first stop is `SECURITY.md` (e.g. a vulnerability reporter scoping their research) will leave with a false understanding of the threat model before they ever reach `SECURITY-MODEL.md §2`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20SECURITY.md%0ALine%3A%203%0A%0AComment%3A%0A**Intro%20still%20overgeneralises%20key%20location%20to%20%60%23fragment%60**%0A%0AThe%20opening%20paragraph%20states%20%22the%20decryption%20key%20lives%20only%20in%20the%20URL%20%60%23fragment%60%22%2C%20but%20this%20PR's%20whole%20purpose%20is%20to%20document%20that%20password-protected%20pastes%20have%20no%20fragment%20at%20all%20%E2%80%94%20the%20AES%20key%20is%20PBKDF2-derived%20in%20the%20browser%20and%20never%20placed%20in%20the%20URL.%20A%20reader%20whose%20first%20stop%20is%20%60SECURITY.md%60%20%28e.g.%20a%20vulnerability%20reporter%20scoping%20their%20research%29%20will%20leave%20with%20a%20false%20understanding%20of%20the%20threat%20model%20before%20they%20ever%20reach%20%60SECURITY-MODEL.md%20%C2%A72%60.%0A%0A%60%60%60suggestion%0ACloakBin%20is%20a%20**zero-knowledge%20encrypted%20pastebin**%3A%20encryption%20happens%20in%20the%20browser%20and%20the%20decryption%20key%20never%20reaches%20the%20server%20%E2%80%94%20for%20random%20pastes%20it%20lives%20in%20the%20URL%20%60%23fragment%60%3B%20for%20password-protected%20pastes%20it%20is%20derived%20client-side%20with%20PBKDF2%20and%20never%20transmitted.%20The%20server%20stores%20only%20ciphertext.%20Because%20privacy%20is%20the%20entire%20point%20of%20the%20project%2C%20we%20treat%20any%20issue%20that%20could%20leak%20plaintext%2C%20keys%2C%20or%20user%20data%20%E2%80%94%20or%20that%20weakens%20the%20client-side%20cryptography%20%E2%80%94%20as%20**high%20priority**.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ishannaik%2Fcloakbin&pr=161&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22docs%2Fsecurity-model-nits%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fsecurity-model-nits%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20SECURITY.md%0ALine%3A%203%0A%0AComment%3A%0A**Intro%20still%20overgeneralises%20key%20location%20to%20%60%23fragment%60**%0A%0AThe%20opening%20paragraph%20states%20%22the%20decryption%20key%20lives%20only%20in%20the%20URL%20%60%23fragment%60%22%2C%20but%20this%20PR's%20whole%20purpose%20is%20to%20document%20that%20password-protected%20pastes%20have%20no%20fragment%20at%20all%20%E2%80%94%20the%20AES%20key%20is%20PBKDF2-derived%20in%20the%20browser%20and%20never%20placed%20in%20the%20URL.%20A%20reader%20whose%20first%20stop%20is%20%60SECURITY.md%60%20%28e.g.%20a%20vulnerability%20reporter%20scoping%20their%20research%29%20will%20leave%20with%20a%20false%20understanding%20of%20the%20threat%20model%20before%20they%20ever%20reach%20%60SECURITY-MODEL.md%20%C2%A72%60.%0A%0A%60%60%60suggestion%0ACloakBin%20is%20a%20**zero-knowledge%20encrypted%20pastebin**%3A%20encryption%20happens%20in%20the%20browser%20and%20the%20decryption%20key%20never%20reaches%20the%20server%20%E2%80%94%20for%20random%20pastes%20it%20lives%20in%20the%20URL%20%60%23fragment%60%3B%20for%20password-protected%20pastes%20it%20is%20derived%20client-side%20with%20PBKDF2%20and%20never%20transmitted.%20The%20server%20stores%20only%20ciphertext.%20Because%20privacy%20is%20the%20entire%20point%20of%20the%20project%2C%20we%20treat%20any%20issue%20that%20could%20leak%20plaintext%2C%20keys%2C%20or%20user%20data%20%E2%80%94%20or%20that%20weakens%20the%20client-side%20cryptography%20%E2%80%94%20as%20**high%20priority**.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ishannaik%2Fcloakbin&pr=161&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20SECURITY.md%0ALine%3A%203%0A%0AComment%3A%0A**Intro%20still%20overgeneralises%20key%20location%20to%20%60%23fragment%60**%0A%0AThe%20opening%20paragraph%20states%20%22the%20decryption%20key%20lives%20only%20in%20the%20URL%20%60%23fragment%60%22%2C%20but%20this%20PR's%20whole%20purpose%20is%20to%20document%20that%20password-protected%20pastes%20have%20no%20fragment%20at%20all%20%E2%80%94%20the%20AES%20key%20is%20PBKDF2-derived%20in%20the%20browser%20and%20never%20placed%20in%20the%20URL.%20A%20reader%20whose%20first%20stop%20is%20%60SECURITY.md%60%20%28e.g.%20a%20vulnerability%20reporter%20scoping%20their%20research%29%20will%20leave%20with%20a%20false%20understanding%20of%20the%20threat%20model%20before%20they%20ever%20reach%20%60SECURITY-MODEL.md%20%C2%A72%60.%0A%0A%60%60%60suggestion%0ACloakBin%20is%20a%20**zero-knowledge%20encrypted%20pastebin**%3A%20encryption%20happens%20in%20the%20browser%20and%20the%20decryption%20key%20never%20reaches%20the%20server%20%E2%80%94%20for%20random%20pastes%20it%20lives%20in%20the%20URL%20%60%23fragment%60%3B%20for%20password-protected%20pastes%20it%20is%20derived%20client-side%20with%20PBKDF2%20and%20never%20transmitted.%20The%20server%20stores%20only%20ciphertext.%20Because%20privacy%20is%20the%20entire%20point%20of%20the%20project%2C%20we%20treat%20any%20issue%20that%20could%20leak%20plaintext%2C%20keys%2C%20or%20user%20data%20%E2%80%94%20or%20that%20weakens%20the%20client-side%20cryptography%20%E2%80%94%20as%20**high%20priority**.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=161&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASECURITY.md%3A3%0A**Intro%20still%20overgeneralises%20key%20location%20to%20%60%23fragment%60**%0A%0AThe%20opening%20paragraph%20states%20%22the%20decryption%20key%20lives%20only%20in%20the%20URL%20%60%23fragment%60%22%2C%20but%20this%20PR's%20whole%20purpose%20is%20to%20document%20that%20password-protected%20pastes%20have%20no%20fragment%20at%20all%20%E2%80%94%20the%20AES%20key%20is%20PBKDF2-derived%20in%20the%20browser%20and%20never%20placed%20in%20the%20URL.%20A%20reader%20whose%20first%20stop%20is%20%60SECURITY.md%60%20%28e.g.%20a%20vulnerability%20reporter%20scoping%20their%20research%29%20will%20leave%20with%20a%20false%20understanding%20of%20the%20threat%20model%20before%20they%20ever%20reach%20%60SECURITY-MODEL.md%20%C2%A72%60.%0A%0A%60%60%60suggestion%0ACloakBin%20is%20a%20**zero-knowledge%20encrypted%20pastebin**%3A%20encryption%20happens%20in%20the%20browser%20and%20the%20decryption%20key%20never%20reaches%20the%20server%20%E2%80%94%20for%20random%20pastes%20it%20lives%20in%20the%20URL%20%60%23fragment%60%3B%20for%20password-protected%20pastes%20it%20is%20derived%20client-side%20with%20PBKDF2%20and%20never%20transmitted.%20The%20server%20stores%20only%20ciphertext.%20Because%20privacy%20is%20the%20entire%20point%20of%20the%20project%2C%20we%20treat%20any%20issue%20that%20could%20leak%20plaintext%2C%20keys%2C%20or%20user%20data%20%E2%80%94%20or%20that%20weakens%20the%20client-side%20cryptography%20%E2%80%94%20as%20**high%20priority**.%0A%60%60%60%0A%0A&repo=ishannaik%2Fcloakbin&pr=161&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22docs%2Fsecurity-model-nits%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fsecurity-model-nits%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASECURITY.md%3A3%0A**Intro%20still%20overgeneralises%20key%20location%20to%20%60%23fragment%60**%0A%0AThe%20opening%20paragraph%20states%20%22the%20decryption%20key%20lives%20only%20in%20the%20URL%20%60%23fragment%60%22%2C%20but%20this%20PR's%20whole%20purpose%20is%20to%20document%20that%20password-protected%20pastes%20have%20no%20fragment%20at%20all%20%E2%80%94%20the%20AES%20key%20is%20PBKDF2-derived%20in%20the%20browser%20and%20never%20placed%20in%20the%20URL.%20A%20reader%20whose%20first%20stop%20is%20%60SECURITY.md%60%20%28e.g.%20a%20vulnerability%20reporter%20scoping%20their%20research%29%20will%20leave%20with%20a%20false%20understanding%20of%20the%20threat%20model%20before%20they%20ever%20reach%20%60SECURITY-MODEL.md%20%C2%A72%60.%0A%0A%60%60%60suggestion%0ACloakBin%20is%20a%20**zero-knowledge%20encrypted%20pastebin**%3A%20encryption%20happens%20in%20the%20browser%20and%20the%20decryption%20key%20never%20reaches%20the%20server%20%E2%80%94%20for%20random%20pastes%20it%20lives%20in%20the%20URL%20%60%23fragment%60%3B%20for%20password-protected%20pastes%20it%20is%20derived%20client-side%20with%20PBKDF2%20and%20never%20transmitted.%20The%20server%20stores%20only%20ciphertext.%20Because%20privacy%20is%20the%20entire%20point%20of%20the%20project%2C%20we%20treat%20any%20issue%20that%20could%20leak%20plaintext%2C%20keys%2C%20or%20user%20data%20%E2%80%94%20or%20that%20weakens%20the%20client-side%20cryptography%20%E2%80%94%20as%20**high%20priority**.%0A%60%60%60%0A%0A&repo=ishannaik%2Fcloakbin&pr=161&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ASECURITY.md%3A3%0A**Intro%20still%20overgeneralises%20key%20location%20to%20%60%23fragment%60**%0A%0AThe%20opening%20paragraph%20states%20%22the%20decryption%20key%20lives%20only%20in%20the%20URL%20%60%23fragment%60%22%2C%20but%20this%20PR's%20whole%20purpose%20is%20to%20document%20that%20password-protected%20pastes%20have%20no%20fragment%20at%20all%20%E2%80%94%20the%20AES%20key%20is%20PBKDF2-derived%20in%20the%20browser%20and%20never%20placed%20in%20the%20URL.%20A%20reader%20whose%20first%20stop%20is%20%60SECURITY.md%60%20%28e.g.%20a%20vulnerability%20reporter%20scoping%20their%20research%29%20will%20leave%20with%20a%20false%20understanding%20of%20the%20threat%20model%20before%20they%20ever%20reach%20%60SECURITY-MODEL.md%20%C2%A72%60.%0A%0A%60%60%60suggestion%0ACloakBin%20is%20a%20**zero-knowledge%20encrypted%20pastebin**%3A%20encryption%20happens%20in%20the%20browser%20and%20the%20decryption%20key%20never%20reaches%20the%20server%20%E2%80%94%20for%20random%20pastes%20it%20lives%20in%20the%20URL%20%60%23fragment%60%3B%20for%20password-protected%20pastes%20it%20is%20derived%20client-side%20with%20PBKDF2%20and%20never%20transmitted.%20The%20server%20stores%20only%20ciphertext.%20Because%20privacy%20is%20the%20entire%20point%20of%20the%20project%2C%20we%20treat%20any%20issue%20that%20could%20leak%20plaintext%2C%20keys%2C%20or%20user%20data%20%E2%80%94%20or%20that%20weakens%20the%20client-side%20cryptography%20%E2%80%94%20as%20**high%20priority**.%0A%60%60%60%0A%0A&pr=161&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
SECURITY.md:3
**Intro still overgeneralises key location to `#fragment`**

The opening paragraph states "the decryption key lives only in the URL `#fragment`", but this PR's whole purpose is to document that password-protected pastes have no fragment at all — the AES key is PBKDF2-derived in the browser and never placed in the URL. A reader whose first stop is `SECURITY.md` (e.g. a vulnerability reporter scoping their research) will leave with a false understanding of the threat model before they ever reach `SECURITY-MODEL.md §2`.

```suggestion
CloakBin is a **zero-knowledge encrypted pastebin**: encryption happens in the browser and the decryption key never reaches the server — for random pastes it lives in the URL `#fragment`; for password-protected pastes it is derived client-side with PBKDF2 and never transmitted. The server stores only ciphertext. Because privacy is the entire point of the project, we treat any issue that could leak plaintext, keys, or user data — or that weakens the client-side cryptography — as **high priority**.
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(security): address post-merge SECUR..."](https://github.com/ishannaik/cloakbin/commit/7e68050a5583e2f3b51a8538f08c5e8852d5de9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46820303)</sub>

<!-- /greptile_comment -->