### PR TITLE
feat: add raw view exit links

### DIFF
--- a/src/routes/r/[id]/+page.svelte
+++ b/src/routes/r/[id]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { onMount } from 'svelte';
 	import { decrypt, base64ToKey } from '$lib/crypto';
@@ -6,6 +7,7 @@
 	let content = $state('');
 	let viewState = $state<'loading' | 'error' | 'success' | 'needKey'>('loading');
 	let errorMessage = $state('');
+	let fullViewHref = $state('');
 
 	onMount(async () => {
 		try {
@@ -15,9 +17,10 @@
 			if (!response.ok) {
 				const errorData = await response.json();
 				viewState = 'error';
-				errorMessage = response.status === 404
-					? 'Paste not found or expired'
-					: errorData.error || 'Failed to fetch paste';
+				errorMessage =
+					response.status === 404
+						? 'Paste not found or expired'
+						: errorData.error || 'Failed to fetch paste';
 				return;
 			}
 
@@ -33,6 +36,7 @@
 			const key = await base64ToKey(urlHash);
 			const decryptedContent = await decrypt(data.content, key);
 			content = decryptedContent;
+			fullViewHref = `/p/${pasteId}${window.location.hash}`;
 			viewState = 'success';
 		} catch (error) {
 			console.error('Error loading paste:', error);
@@ -40,6 +44,11 @@
 			errorMessage = 'Failed to decrypt. Invalid key?';
 		}
 	});
+
+	function editAsNew() {
+		sessionStorage.setItem('cloakbin_duplicate', content);
+		goto('/');
+	}
 </script>
 
 <svelte:head>
@@ -51,6 +60,10 @@
 {:else if viewState === 'error' || viewState === 'needKey'}
 	<pre class="raw-content">Error: {errorMessage}</pre>
 {:else}
+	<div class="raw-actions">
+		<a href={fullViewHref}>Full view</a>
+		<button type="button" onclick={editAsNew}>Edit as new</button>
+	</div>
 	<pre class="raw-content">{content}</pre>
 {/if}
 
@@ -73,5 +86,32 @@
 		word-wrap: break-word;
 		min-height: 100vh;
 		box-sizing: border-box;
+	}
+
+	.raw-actions {
+		display: flex;
+		gap: 12px;
+		align-items: center;
+		padding: 12px 16px;
+		background: #111318;
+		border-bottom: 1px solid #2f333d;
+		font-family: system-ui, sans-serif;
+	}
+
+	.raw-actions a,
+	.raw-actions button {
+		color: #5eead4;
+		background: transparent;
+		border: 0;
+		padding: 0;
+		font: inherit;
+		text-decoration: none;
+		cursor: pointer;
+	}
+
+	.raw-actions a:hover,
+	.raw-actions button:hover {
+		color: #99f6e4;
+		text-decoration: underline;
 	}
 </style>


### PR DESCRIPTION
## Summary

- Add a success-only action bar to the raw paste view.
- Link back to `/p/[id]` while preserving the current `#key` fragment.
- Add an "Edit as new" button that writes decrypted content to `sessionStorage.cloakbin_duplicate` and redirects home, reusing the existing duplicate flow.

Fixes #174.

## Validation

- `./node_modules/.bin/prettier --check 'src/routes/r/[id]/+page.svelte'`
- `./node_modules/.bin/eslint 'src/routes/r/[id]/+page.svelte'`
- `./node_modules/.bin/svelte-kit sync && ./node_modules/.bin/svelte-check --tsconfig ./tsconfig.json` (passes with existing warnings in unrelated files)
- `./node_modules/.bin/vitest run`
- `DB_TYPE=memory ./node_modules/.bin/vite build` (passes with existing warnings in unrelated files)
- `DB_TYPE=memory ./node_modules/.bin/vite dev --host 127.0.0.1 --port 5173`, then `curl -I http://127.0.0.1:5173/` and `curl -I http://127.0.0.1:5173/r/example` returned `200 OK`

Notes: full `pnpm lint` and full `pnpm format:check` currently fail on pre-existing unrelated files; the touched raw route passes focused ESLint and Prettier checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Full view** link for easier reading of decrypted content.
  * Added an **Edit as new** action that lets you open decrypted content in the editor for modification.
  * Added a styled action bar above displayed content for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an action bar to the raw paste view (`/r/[id]`) that appears only on successful decryption. It provides a "Full view" link back to `/p/[id]` (preserving the URL hash/key fragment) and an "Edit as new" button that writes decrypted content to `sessionStorage.cloakbin_duplicate` before navigating home — reusing the existing duplicate flow already present in `/p/[id]/+page.svelte`.

- The new `editAsNew` function mirrors the existing `duplicatePaste` in `p/[id]/+page.svelte` exactly, and `sessionStorage.cloakbin_duplicate` is already consumed by the home page's `checkForDuplicate`.
- `fullViewHref` is set immediately before `viewState = 'success'`, so the action bar never renders with an empty href.
- CSS is scoped to `.raw-actions` with hover states matching the site's teal palette.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is small, additive, and consistent with existing patterns in the codebase.

The action bar only renders after a successful decryption, fullViewHref is always populated before viewState transitions to 'success', and editAsNew is a direct copy of the already-tested duplicatePaste pattern used in /p/[id]/+page.svelte. No new API surface, no new state management concerns, and the sessionStorage key is consumed and cleaned up by the existing home-page handler.

**Files Needing Attention:** No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/r/[id]/+page.svelte | Adds a success-only action bar with a 'Full view' link and 'Edit as new' button; logic correctly mirrors the existing duplicate flow and guards against rendering before the href is populated. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant RawView as /r/[id] (Raw View)
    participant FullView as /p/[id] (Full View)
    participant Home as / (Home)
    participant SS as sessionStorage

    User->>RawView: "Visit /r/[id]#key"
    RawView->>RawView: fetch /api/paste/[id]
    RawView->>RawView: decrypt(content, key)
    RawView->>RawView: "fullViewHref = /p/[id]#key"
    RawView->>RawView: "viewState = 'success'"
    RawView->>User: Show raw content + action bar

    alt Full view clicked
        User->>RawView: click Full view
        RawView->>FullView: "navigate to /p/[id]#key"
        FullView->>User: Show formatted paste
    else Edit as new clicked
        User->>RawView: click Edit as new
        RawView->>SS: setItem('cloakbin_duplicate', content)
        RawView->>Home: goto('/')
        Home->>SS: getItem('cloakbin_duplicate')
        SS-->>Home: decrypted content
        Home->>SS: removeItem('cloakbin_duplicate')
        Home->>User: Pre-fill editor with content
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add raw view exit links"](https://github.com/ishannaik/cloakbin/commit/ec62affc4f6cc644b7fe7701de11fa7673088773) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48221749)</sub>

<!-- /greptile_comment -->