### PR TITLE
fix(cli): reject --host values without an http(s) scheme

### DIFF
--- a/cli/bin/cloakbin.js
+++ b/cli/bin/cloakbin.js
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { encrypt, decrypt } from '../src/crypto.js';
 import { detectLanguage } from '../src/lang-detect.js';
 import { resolveExpiry } from '../src/duration.js';
+import { validateHost as _validateHost } from '../src/host.js';
 
 const VERSION = '0.1.0';
 const DEFAULT_HOST = 'https://cloakbin.com';
@@ -33,6 +34,7 @@ function fail(msg) {
   process.stderr.write(`Error: ${msg}\n`);
   process.exit(1);
 }
+
 
 /** Hand-rolled flag parser: supports --flag value and --flag=value */
 function parseArgs(argv) {
@@ -95,7 +97,11 @@ function parseArgs(argv) {
         case 'host':
           value = value !== undefined ? value : argv[++i];
           if (value === undefined) fail('--host requires a value');
-          flags.host = value;
+          try {
+            flags.host = _validateHost(value);
+          } catch (err) {
+            fail(err.message);
+          }
           break;
         default:
           fail(`unknown flag --${name}`);

--- a/cli/src/host.js
+++ b/cli/src/host.js
@@ -1,0 +1,22 @@
+/**
+ * Require an absolute http(s) URL for --host. Do not guess a scheme.
+ * @param {string} value
+ * @returns {string} the original value when valid
+ * @throws {Error} when the value is missing a scheme or is not a URL
+ */
+export function validateHost(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(
+      `--host must be a valid URL with http:// or https:// scheme (got ${JSON.stringify(value)})`,
+    );
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(
+      `--host must use http:// or https:// scheme (got ${JSON.stringify(value)})`,
+    );
+  }
+  return value;
+}

--- a/cli/test/units.test.js
+++ b/cli/test/units.test.js
@@ -6,6 +6,7 @@
 import assert from 'node:assert/strict';
 import { detectLanguage, LANGUAGE_MAP } from '../src/lang-detect.js';
 import { parseDuration, resolveExpiry } from '../src/duration.js';
+import { validateHost } from '../src/host.js';
 
 let passed = 0;
 let failed = 0;
@@ -190,6 +191,36 @@ async function run() {
 
   await test('resolveExpiry invalid foo → null', () => {
     assert.equal(resolveExpiry('foo'), null);
+  });
+
+  // --- validateHost ---
+  await test('validateHost rejects host without scheme', () => {
+    assert.throws(
+      () => validateHost('paste.example.com'),
+      (err) => /http:\/\/ or https:\/\//i.test(err.message) && /paste\.example\.com/.test(err.message),
+    );
+  });
+
+  await test('validateHost rejects non-URL values', () => {
+    assert.throws(
+      () => validateHost('not a url'),
+      (err) => /valid URL|http:\/\/ or https:\/\//i.test(err.message),
+    );
+  });
+
+  await test('validateHost accepts https with trailing slash', () => {
+    assert.equal(validateHost('https://example.com/'), 'https://example.com/');
+  });
+
+  await test('validateHost accepts http without trailing slash', () => {
+    assert.equal(validateHost('http://localhost:5173'), 'http://localhost:5173');
+  });
+
+  await test('validateHost rejects non-http schemes', () => {
+    assert.throws(
+      () => validateHost('ftp://files.example.com'),
+      (err) => /http:\/\/ or https:\/\//i.test(err.message),
+    );
   });
 
   console.log(`\n${passed} passed, ${failed} failed`);


### PR DESCRIPTION
## Summary
`--host` was accepted as any string. Values without a scheme (e.g. `paste.example.com`) only failed later inside `fetch()` with an opaque error.

This validates `--host` at parse time and requires an absolute `http://` or `https://` URL. Schemes are not guessed.

## Changes
- Add `cli/src/host.js` with `validateHost()`
- Wire it into the `case 'host'` branch in `cli/bin/cloakbin.js`
- Unit tests for missing scheme, invalid URL, non-http schemes, and valid hosts

## Test plan
- [x] `cd cli && node test/units.test.js` (33 passed)
- [ ] Manual: `cloakbin --host paste.example.com --version` exits non-zero with a clear message
- [ ] Manual: `cloakbin --host https://example.com --version` still works

Fixes #187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for host values supplied through the CLI.
  * Host values must now be valid absolute HTTP or HTTPS URLs.
  * Invalid, missing, or unsupported host values produce clear validation errors instead of being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds upfront validation of the `--host` CLI flag, rejecting any value that lacks an `http://` or `https://` scheme. Previously, invalid hostnames would fail later inside `fetch()` with an opaque error.

- Introduces `cli/src/host.js` with a `validateHost()` function that uses the WHATWG `URL` constructor for parsing and explicitly checks the protocol, then wires it into the `case 'host'` branch of `parseArgs()`.
- Adds five unit tests covering missing scheme, invalid URL, non-http schemes, and two valid inputs.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the validation logic is correct, the error messages are clear, and all edge cases (missing scheme, invalid URL, non-http schemes) are covered by tests.

The core change is straightforward and correct. The only thing worth noting is the `_validateHost` import alias, which is unconventional and could mislead tooling into flagging the import as unused.

**Files Needing Attention:** No files require special attention; the import alias in `cli/bin/cloakbin.js` is the one minor point worth a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cli/src/host.js | New validator: uses WHATWG URL constructor and explicit protocol check; logic is correct and error messages are user-friendly. |
| cli/bin/cloakbin.js | Wires validateHost into the host flag case with a try/catch that routes to fail(); import alias _validateHost uses an underscore convention that may mislead static analysis tools into treating it as intentionally unused. |
| cli/test/units.test.js | Five new validateHost tests cover the main code paths; regex matchers are appropriate for the error messages produced. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant cloakbin.js
    participant host.js
    participant fetch

    User->>cloakbin.js: "cloakbin --host value"
    cloakbin.js->>host.js: validateHost(value)
    alt invalid URL or missing scheme
        host.js-->>cloakbin.js: throw Error
        cloakbin.js-->>User: "Error: --host must be a valid URL (exit 1)"
    else non-http(s) scheme
        host.js-->>cloakbin.js: throw Error
        cloakbin.js-->>User: "Error: --host must use http:// or https:// (exit 1)"
    else valid https or http
        host.js-->>cloakbin.js: return value
        cloakbin.js->>cloakbin.js: strip trailing slash
        cloakbin.js->>fetch: "fetch(host + /api/paste)"
        fetch-->>cloakbin.js: response
        cloakbin.js-->>User: paste URL
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acli%2Fbin%2Fcloakbin.js%3A7%0AThe%20%60_validateHost%60%20alias%20isn't%20needed%20here%20%E2%80%94%20the%20local%20name%20never%20conflicts%20with%20anything%20in%20this%20file.%20Leading%20underscores%20conventionally%20signal%20%22intentionally%20unused%22%20in%20JavaScript%20%28ESLint's%20%60no-unused-vars%60%2C%20many%20linters%29%2C%20so%20this%20alias%20may%20confuse%20static%20analysis%20tools%20or%20future%20readers%20into%20thinking%20the%20import%20is%20dead%20code.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20validateHost%20%7D%20from%20'..%2Fsrc%2Fhost.js'%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=188&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22fix%2Fcli-host-scheme-validation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcli-host-scheme-validation%22.%0A%0A%23%23%23%20Issue%201%0Acli%2Fbin%2Fcloakbin.js%3A7%0AThe%20%60_validateHost%60%20alias%20isn't%20needed%20here%20%E2%80%94%20the%20local%20name%20never%20conflicts%20with%20anything%20in%20this%20file.%20Leading%20underscores%20conventionally%20signal%20%22intentionally%20unused%22%20in%20JavaScript%20%28ESLint's%20%60no-unused-vars%60%2C%20many%20linters%29%2C%20so%20this%20alias%20may%20confuse%20static%20analysis%20tools%20or%20future%20readers%20into%20thinking%20the%20import%20is%20dead%20code.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20validateHost%20%7D%20from%20'..%2Fsrc%2Fhost.js'%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=188&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Acli%2Fbin%2Fcloakbin.js%3A7%0AThe%20%60_validateHost%60%20alias%20isn't%20needed%20here%20%E2%80%94%20the%20local%20name%20never%20conflicts%20with%20anything%20in%20this%20file.%20Leading%20underscores%20conventionally%20signal%20%22intentionally%20unused%22%20in%20JavaScript%20%28ESLint's%20%60no-unused-vars%60%2C%20many%20linters%29%2C%20so%20this%20alias%20may%20confuse%20static%20analysis%20tools%20or%20future%20readers%20into%20thinking%20the%20import%20is%20dead%20code.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20validateHost%20%7D%20from%20'..%2Fsrc%2Fhost.js'%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=188&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
cli/bin/cloakbin.js:7
The `_validateHost` alias isn't needed here — the local name never conflicts with anything in this file. Leading underscores conventionally signal "intentionally unused" in JavaScript (ESLint's `no-unused-vars`, many linters), so this alias may confuse static analysis tools or future readers into thinking the import is dead code.

```suggestion
import { validateHost } from '../src/host.js';
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): reject --host values without a..."](https://github.com/ishannaik/cloakbin/commit/aa65fdfbf84be193ff46b915f48863bd866363bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49995614)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->