### PR TITLE
fix(api): include active db adapter name in /api/health

### DIFF
--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -1,5 +1,6 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+import { env } from '$env/dynamic/private';
 import { db } from '$lib/db';
 
 export const GET: RequestHandler = async () => {
@@ -8,7 +9,7 @@ export const GET: RequestHandler = async () => {
         if (!result.success) {
             return json({ ok: false, error: 'database unavailable' }, { status: 503 });
         }
-        return json({ ok: true }, { status: 200 });
+        return json({ ok: true, db: env.DB_TYPE }, { status: 200 });
     } catch {
         return json({ ok: false, error: 'database unavailable' }, { status: 503 });
     }


### PR DESCRIPTION
## Summary
`GET /api/health` returned `{ ok: true }` while the README documents `{ "ok": true, "db": "mongodb" }`. Anyone wiring a health check against the documented shape saw `db` as undefined.

## Changes
- On success, include `db` from `DB_TYPE` (e.g. `memory`, `mongodb`)
- 503 error responses keep their existing shape

Chose to align the code with the README rather than rewrite the docs, since the documented field is useful for operators.

## Test plan
- [ ] `DB_TYPE=memory pnpm dev` then `curl -s localhost:5173/api/health` → includes `"db":"memory"`
- [ ] Unhealthy path still returns 503 with `{ ok: false, error: "database unavailable" }`

Fixes #180

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns the `/api/health` route response with the documented API shape, adding the `db` field drawn from `env.DB_TYPE` to successful health responses. The error path is unchanged.

- Adds `db: env.DB_TYPE` to the 200 response, matching the README's documented `{ "ok": true, "db": "mongodb" }` shape.
- Uses `$env/dynamic/private` to read `DB_TYPE`, which is already validated and required for the `$lib/db` module to initialise — so if the app is running, the value is always a non-empty string.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is a single-line addition that aligns runtime behaviour with the documented API contract.

The change is minimal and correct: `env.DB_TYPE` is already guaranteed to be set by the time any request reaches this handler (the `$lib/db` module throws at initialisation if it is absent), so the `db` field will always be a non-empty string in the response. The only notable trade-off is that an unauthenticated public endpoint now advertises the active database adapter, which is intentional per the README but is worth a second look for operators who prefer a private health surface.

**Files Needing Attention:** No files require special attention beyond the single-line change in `src/routes/api/health/+server.ts`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/api/health/+server.ts | Adds `db: env.DB_TYPE` to the 200 health response; the public endpoint now exposes the active adapter name, which is intentional per the README but worth noting for operators who want a fully private health surface. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant HealthRoute as GET /api/health
    participant DB as db.healthCheck()
    participant Env as env.DB_TYPE

    Client->>HealthRoute: GET /api/health
    HealthRoute->>DB: healthCheck()
    alt success
        DB-->>HealthRoute: "{ success: true }"
        HealthRoute->>Env: read DB_TYPE
        Env-->>HealthRoute: "memory" | "mongodb"
        HealthRoute-->>Client: "200 { ok: true, db: "mongodb" }"
    else "result.success === false"
        DB-->>HealthRoute: "{ success: false }"
        HealthRoute-->>Client: "503 { ok: false, error: "database unavailable" }"
    else throws
        DB-->>HealthRoute: throws
        HealthRoute-->>Client: "503 { ok: false, error: "database unavailable" }"
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Froutes%2Fapi%2Fhealth%2F%2Bserver.ts%3A12%0A**Public%20endpoint%20leaks%20infrastructure%20detail**%0A%0A%60%2Fapi%2Fhealth%60%20is%20unauthenticated%2C%20so%20the%20adapter%20name%20%28%60memory%60%2C%20%60mongodb%60%2C%20etc.%29%20is%20now%20visible%20to%20any%20external%20caller.%20The%20README%20deliberately%20documents%20this%20field%2C%20so%20the%20disclosure%20is%20intentional%20%E2%80%94%20but%20worth%20being%20aware%20of%3A%20if%20the%20list%20of%20supported%20adapters%20grows%20to%20include%20more%20distinctive%20backend%20technologies%2C%20operators%20may%20want%20to%20gate%20this%20endpoint%20behind%20a%20network-level%20control%20or%20an%20internal-only%20route%20rather%20than%20exposing%20it%20on%20the%20public%20surface.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=189&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22fix%2Fhealth-include-db-adapter%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhealth-include-db-adapter%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Froutes%2Fapi%2Fhealth%2F%2Bserver.ts%3A12%0A**Public%20endpoint%20leaks%20infrastructure%20detail**%0A%0A%60%2Fapi%2Fhealth%60%20is%20unauthenticated%2C%20so%20the%20adapter%20name%20%28%60memory%60%2C%20%60mongodb%60%2C%20etc.%29%20is%20now%20visible%20to%20any%20external%20caller.%20The%20README%20deliberately%20documents%20this%20field%2C%20so%20the%20disclosure%20is%20intentional%20%E2%80%94%20but%20worth%20being%20aware%20of%3A%20if%20the%20list%20of%20supported%20adapters%20grows%20to%20include%20more%20distinctive%20backend%20technologies%2C%20operators%20may%20want%20to%20gate%20this%20endpoint%20behind%20a%20network-level%20control%20or%20an%20internal-only%20route%20rather%20than%20exposing%20it%20on%20the%20public%20surface.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=189&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Froutes%2Fapi%2Fhealth%2F%2Bserver.ts%3A12%0A**Public%20endpoint%20leaks%20infrastructure%20detail**%0A%0A%60%2Fapi%2Fhealth%60%20is%20unauthenticated%2C%20so%20the%20adapter%20name%20%28%60memory%60%2C%20%60mongodb%60%2C%20etc.%29%20is%20now%20visible%20to%20any%20external%20caller.%20The%20README%20deliberately%20documents%20this%20field%2C%20so%20the%20disclosure%20is%20intentional%20%E2%80%94%20but%20worth%20being%20aware%20of%3A%20if%20the%20list%20of%20supported%20adapters%20grows%20to%20include%20more%20distinctive%20backend%20technologies%2C%20operators%20may%20want%20to%20gate%20this%20endpoint%20behind%20a%20network-level%20control%20or%20an%20internal-only%20route%20rather%20than%20exposing%20it%20on%20the%20public%20surface.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=189&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/routes/api/health/+server.ts:12
**Public endpoint leaks infrastructure detail**

`/api/health` is unauthenticated, so the adapter name (`memory`, `mongodb`, etc.) is now visible to any external caller. The README deliberately documents this field, so the disclosure is intentional — but worth being aware of: if the list of supported adapters grows to include more distinctive backend technologies, operators may want to gate this endpoint behind a network-level control or an internal-only route rather than exposing it on the public surface.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): include active db adapter name..."](https://github.com/ishannaik/cloakbin/commit/72cc4da9191e8260cf709f30630bd16337ce3b18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49995623)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->