### PR TITLE
fix: ship a single theme-color meta matching the webmanifest

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -112,7 +112,6 @@
 	/>
 	<meta name="author" content="CloakBin" />
 	<meta name="robots" content="index, follow" />
-	<meta name="theme-color" content="#14b8a6" />
 	<meta name="color-scheme" content="dark" />
 
 	<!-- Canonical -->


### PR DESCRIPTION
## Summary
The app rendered two `theme-color` meta tags with different values:
- `src/app.html` → `#1d2731` (matches `static/site.webmanifest`)
- `src/routes/+layout.svelte` → `#14b8a6` (won because it comes later)

Mobile browser chrome and the installed-app color disagreed.

## Changes
- Remove the layout override
- Keep `#1d2731` from `app.html`, matching the webmanifest

Kept the webmanifest color so PWA install chrome and document meta stay aligned.

## Test plan
- [ ] View page source / head: only one `theme-color`, value `#1d2731`
- [ ] `site.webmanifest` `theme_color` still `#1d2731`

Fixes #178

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes a single `<meta name="theme-color">` line from `src/routes/+layout.svelte` that was overriding the one declared in `src/app.html`. Because SvelteKit injects `<svelte:head>` content after the static `app.html` head, the layout's teal value (`#14b8a6`) was winning over the dark navy value (`#1d2731`) that matches the web app manifest, causing a mismatch between the installed-PWA chrome color and the browser tab color.

- Removes `<meta name="theme-color" content="#14b8a6" />` from the layout, leaving the single authoritative tag in `app.html` (`#1d2731`).
- Aligns the document `theme-color` with `site.webmanifest`'s `theme_color`, so PWA install chrome and browser UI chrome now agree.
</details>

<h3>Confidence Score: 5/5</h3>

A safe, surgical one-line removal that resolves a visible PWA/browser chrome color mismatch with no side effects.

The change is a single-line deletion of a duplicate meta tag. The remaining theme-color in app.html and the webmanifest's theme_color both carry the same #1d2731 value, so they are now consistent. No logic, routing, or data-handling code is touched, and no other meta tags are affected.

**Files Needing Attention:** No files require special attention — the only changed file has a straightforward, easily verified deletion.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/+layout.svelte | Removes the duplicate theme-color meta tag (#14b8a6) from <svelte:head>, leaving the canonical #1d2731 value in app.html aligned with the webmanifest. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Browser parses head"] --> B["app.html: theme-color = #1d2731"]
    B --> C{"Before this PR"}
    C --> D["layout.svelte svelte:head injected after\ntheme-color = #14b8a6 wins"]
    D --> E["PWA manifest (#1d2731) != Browser chrome (#14b8a6)"]
    C --> F{"After this PR"}
    F --> G["No override in layout.svelte\napp.html value stands: #1d2731"]
    G --> H["PWA manifest (#1d2731) = Browser chrome (#1d2731)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: ship a single theme-color meta matc..."](https://github.com/ishannaik/cloakbin/commit/5a9cc6420a56a6e42d5796cbe8ca0ed6a4c96cec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49995679)</sub>

<!-- /greptile_comment -->