### PR TITLE
a11y: skip-to-content link in root layout

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -157,6 +157,14 @@
 	{@html `<script type="application/ld+json">${jsonLd(structuredData)}</script>`}
 </svelte:head>
 
+<!-- Skip navigation for keyboard / screen reader users -->
+<a
+	href="#main-content"
+	class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[200] focus:rounded-md focus:bg-teal-500 focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-zinc-900"
+>
+	Skip to main content
+</a>
+
 <!-- Navigation progress bar — shows during SvelteKit page transitions -->
 {#if $navigating}
 	<div class="fixed top-0 left-0 right-0 h-0.5 bg-teal-500/20 z-[100]">
@@ -169,7 +177,9 @@
 
 <!-- Easter egg: "cloak" typing fades page to 10% opacity -->
 <div class="transition-opacity duration-500 {isCloaked ? 'opacity-10' : 'opacity-100'}">
-	{@render children()}
+	<main id="main-content" tabindex="-1">
+		{@render children()}
+	</main>
 	<Footer />
 </div>
 

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -112,9 +112,9 @@
 	{/if}
 
 	<!-- Main content -->
-	<main class="flex-1 {isLoginPage ? '' : 'lg:ml-0'}">
+	<div class="flex-1 {isLoginPage ? '' : 'lg:ml-0'}">
 		<div class="mx-auto max-w-7xl {isLoginPage ? 'p-0' : 'p-4 pt-16 sm:p-6 sm:pt-16 lg:p-8 lg:pt-8'}">
 			{@render children()}
 		</div>
-	</main>
+	</div>
 </div>


### PR DESCRIPTION
## Summary
- Visually hidden skip link shown on focus (closes #114)
- Main landmark `id="main-content"` with `tabindex="-1"` for focusable jump target

## Test plan
- [ ] First Tab from load focuses skip link
- [ ] Activating jumps to editor / page content

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a keyboard-accessible skip link and a focusable main-content target in the root layout.
- Adds a visually hidden “Skip to main content” link that becomes visible on focus.
- Wraps rendered routes in a focusable main landmark.
- The wrapper conflicts with the existing main landmark inherited by admin routes.
</details>

<h3>Confidence Score: 4/5</h3>

The nested main landmark on admin routes should be fixed before merging because it undermines the accessibility structure this change is intended to improve.

The root layout now wraps every child route in a main element, while the inherited admin layout already renders its own main element, producing invalid and ambiguous landmark nesting throughout the admin area.

**Files Needing Attention:** src/routes/+layout.svelte, src/routes/admin/+layout.svelte

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/+layout.svelte | Adds the skip-navigation link and target, but creates nested main landmarks on admin routes. |

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Froutes%2F%2Blayout.svelte%3A180%0A**Nested%20main%20landmarks%20on%20admin%20routes**%0A%0AWhen%20an%20%60%2Fadmin%60%20route%20loads%2C%20this%20root%20%60%3Cmain%3E%60%20wraps%20the%20existing%20%60%3Cmain%3E%60%20in%20the%20inherited%20admin%20layout%2C%20producing%20invalid%20nested%20primary%20landmarks%20and%20ambiguous%20landmark%20navigation%20for%20assistive-technology%20users.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22a11y%2Fskip-to-content-114%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22a11y%2Fskip-to-content-114%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Froutes%2F%2Blayout.svelte%3A180%0A**Nested%20main%20landmarks%20on%20admin%20routes**%0A%0AWhen%20an%20%60%2Fadmin%60%20route%20loads%2C%20this%20root%20%60%3Cmain%3E%60%20wraps%20the%20existing%20%60%3Cmain%3E%60%20in%20the%20inherited%20admin%20layout%2C%20producing%20invalid%20nested%20primary%20landmarks%20and%20ambiguous%20landmark%20navigation%20for%20assistive-technology%20users.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Froutes%2F%2Blayout.svelte%3A180%0A**Nested%20main%20landmarks%20on%20admin%20routes**%0A%0AWhen%20an%20%60%2Fadmin%60%20route%20loads%2C%20this%20root%20%60%3Cmain%3E%60%20wraps%20the%20existing%20%60%3Cmain%3E%60%20in%20the%20inherited%20admin%20layout%2C%20producing%20invalid%20nested%20primary%20landmarks%20and%20ambiguous%20landmark%20navigation%20for%20assistive-technology%20users.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/routes/+layout.svelte:180
**Nested main landmarks on admin routes**

When an `/admin` route loads, this root `<main>` wraps the existing `<main>` in the inherited admin layout, producing invalid nested primary landmarks and ambiguous landmark navigation for assistive-technology users.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["a11y: skip-to-content link in root layou..."](https://github.com/ishannaik/cloakbin/commit/d1e6a784ab6accf6d3ccd5f052f5cc13c437d2e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50314772)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added a keyboard-accessible skip-navigation link.
  * Added a focusable main content landmark to improve page navigation for keyboard and assistive technology users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->