### PR TITLE
Reject non-boolean `burnAfterRead` instead of coercing it to truthy

### DIFF
--- a/src/lib/server/burnAfterRead.test.ts
+++ b/src/lib/server/burnAfterRead.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { validateBurnAfterRead } from './burnAfterRead';
+
+describe('validateBurnAfterRead', () => {
+	it('defaults to false when omitted', () => {
+		expect(validateBurnAfterRead(undefined)).toEqual({ valid: true, value: false });
+	});
+
+	it('accepts an explicit boolean true', () => {
+		expect(validateBurnAfterRead(true)).toEqual({ valid: true, value: true });
+	});
+
+	it('accepts an explicit boolean false', () => {
+		expect(validateBurnAfterRead(false)).toEqual({ valid: true, value: false });
+	});
+
+	it('rejects the string "false" instead of coercing it to truthy', () => {
+		expect(validateBurnAfterRead('false')).toEqual({ valid: false });
+	});
+
+	it('rejects the string "true"', () => {
+		expect(validateBurnAfterRead('true')).toEqual({ valid: false });
+	});
+
+	it('rejects numeric values like 1', () => {
+		expect(validateBurnAfterRead(1)).toEqual({ valid: false });
+	});
+
+	it('rejects null', () => {
+		expect(validateBurnAfterRead(null)).toEqual({ valid: false });
+	});
+
+	it('rejects objects/arrays', () => {
+		expect(validateBurnAfterRead({})).toEqual({ valid: false });
+		expect(validateBurnAfterRead([])).toEqual({ valid: false });
+	});
+});

--- a/src/lib/server/burnAfterRead.ts
+++ b/src/lib/server/burnAfterRead.ts
@@ -1,0 +1,25 @@
+/**
+ * Validate the optional `burnAfterRead` flag on paste creation.
+ *
+ * Only an actual boolean should turn burn-after-read on. Anything else
+ * (a stringified "false", a number, an object, ...) is a client bug and
+ * must be rejected with a 400 rather than being coerced to a truthy
+ * value, which would silently burn a paste the user meant to keep.
+ *
+ * Omitting the field entirely is valid and defaults to `false`.
+ */
+export type BurnAfterReadValidation =
+	| { valid: true; value: boolean }
+	| { valid: false };
+
+export function validateBurnAfterRead(value: unknown): BurnAfterReadValidation {
+	if (value === undefined) {
+		return { valid: true, value: false };
+	}
+
+	if (typeof value === 'boolean') {
+		return { valid: true, value };
+	}
+
+	return { valid: false };
+}

--- a/src/routes/api/paste/+server.ts
+++ b/src/routes/api/paste/+server.ts
@@ -20,6 +20,7 @@ import { env } from '$env/dynamic/private';
 import { db } from '$lib/db';
 import { normalizePasteLanguage } from '$lib/languages';
 import { resolveMaxPasteBytes, utf8ByteLength } from '$lib/server/maxPasteBytes';
+import { validateBurnAfterRead } from '$lib/server/burnAfterRead';
 
 /** Max UTF-8 bytes for paste content; override with MAX_PASTE_BYTES (default 10 MiB). */
 const MAX_PASTE_BYTES = resolveMaxPasteBytes(env.MAX_PASTE_BYTES);
@@ -88,6 +89,17 @@ export const POST: RequestHandler = async ({ request }) => {
 		// Calculate expiration date
 		const expiresAt = new Date(Date.now() + EXPIRY_DURATIONS[expiry]);
 
+		// Validate burnAfterRead; only a real boolean may enable it, otherwise a
+		// stringified "false" (or any other truthy-but-wrong value) from a
+		// misbehaving client would silently burn a paste meant to be kept.
+		const burnAfterReadValidation = validateBurnAfterRead(burnAfterRead);
+		if (!burnAfterReadValidation.valid) {
+			return json(
+				{ error: 'burnAfterRead must be a boolean' },
+				{ status: 400 }
+			);
+		}
+
 		// Allowlist language ids; unknown / malicious values fall back to plaintext
 		const safeLanguage = normalizePasteLanguage(language);
 
@@ -97,7 +109,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			expiresAt,
 			hasPassword: !!salt,
 			salt: salt,
-			burnAfterRead: burnAfterRead ?? false,
+			burnAfterRead: burnAfterReadValidation.value,
 			language: safeLanguage
 		});
 


### PR DESCRIPTION
# Reject non-boolean `burnAfterRead` instead of coercing it to truthy

## What & why

`POST /api/paste` passed the raw `burnAfterRead` value from the request body straight through to the database adapter (`burnAfterRead ?? false`), so any truthy-but-not-`true` value — most notably the string `"false"` from a client that stringifies its form fields — silently burned a paste the user meant to keep. Closes #176.

## What changed

- Added `src/lib/server/burnAfterRead.ts` with a small pure `validateBurnAfterRead()` helper (same pattern as the existing `resolveMaxPasteBytes`/`normalizePasteLanguage` helpers): omitting the field defaults to `false`, an actual `boolean` is passed through, and anything else is flagged invalid.
- `src/routes/api/paste/+server.ts` now calls this helper and returns `400 { error: "burnAfterRead must be a boolean" }` for invalid values (matching the existing validation-error shape used for `content`/`expiry`), instead of coercing the value with `??`.
- Added `src/lib/server/burnAfterRead.test.ts` covering `true`, `false`, `"true"`, `"false"`, `1`, `null`, objects/arrays, and the omitted case.

## Testing

```
$ pnpm run test
 Test Files  5 passed (5)
      Tests  38 passed (38)

$ pnpm run type-coverage
(5018 / 5355) 93.70%
type-coverage success.
```

`pnpm lint` reports the same 70 pre-existing problems (18 errors / 52 warnings) on this branch as on `main` before this change — none are in the files touched here, and this PR adds none.

## Type of change

- [x] Bug fix
- [ ] Feature / enhancement
- [ ] CLI
- [ ] Refactor / docs / chore

## Checklist

- [x] `pnpm check` and `pnpm lint` pass (lint has the same pre-existing, unrelated failures as `main`; `pnpm check` reports 0 errors)
- [x] No real secrets or live paste URLs in the diff, tests, or screenshots
- [x] **Touches crypto or key handling?** No — this only validates a plain JSON boolean flag on the paste-creation request; no key/crypto material is involved
- [x] UI changes tested at desktop width and around 390px — N/A, this is a server-side API validation change with no UI
- [x] No new runtime dependency, or the PR explains why one is needed — no new dependency added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Paste creation now consistently handles the optional “burn after read” setting.
  * Omitting the setting defaults it to off, while valid true/false values are preserved.
  * Invalid values are rejected with a clear HTTP 400 error instead of being silently accepted.

* **Tests**
  * Added coverage for default behavior, valid boolean values, and invalid input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR prevents accidental burn-after-read behavior by requiring `burnAfterRead` to be an actual boolean and defaulting an omitted field to `false`.
- Adds a pure validator for the optional flag.
- Returns HTTP 400 for invalid flag types before creating the paste.
- Adds unit coverage for accepted, rejected, and omitted values.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The new validation matches the existing boolean-only request contract, and known callers already send a boolean or omit the field.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/server/burnAfterRead.ts | Adds a clear discriminated-result validator that accepts booleans, defaults omission to false, and rejects all other values. |
| src/routes/api/paste/+server.ts | Applies the validator before persistence and passes only the validated boolean to the database adapter. |
| src/lib/server/burnAfterRead.test.ts | Covers both booleans, omission, strings, numbers, null, objects, and arrays. |

<sub>Reviews (1): Last reviewed commit: ["Reject non-boolean \`burnAfterRead\` inste..."](https://github.com/ishannaik/cloakbin/commit/fd127cd38ccb8becbcb660d6efa7fd5312fe7980) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50377493)</sub>

<!-- /greptile_comment -->