### PR TITLE
fix(cli): reject empty password

### DIFF
--- a/cli/bin/cloakbin.js
+++ b/cli/bin/cloakbin.js
@@ -35,6 +35,11 @@ function fail(msg) {
   process.exit(1);
 }
 
+function requirePassword(value) {
+  if (value === '') fail('password cannot be empty');
+  return value;
+}
+
 
 /** Hand-rolled flag parser: supports --flag value and --flag=value */
 function parseArgs(argv) {
@@ -87,7 +92,7 @@ function parseArgs(argv) {
         case 'password':
           value = value !== undefined ? value : argv[++i];
           if (value === undefined) fail('--password requires a value');
-          flags.password = value;
+          flags.password = requirePassword(value);
           break;
         case 'lang':
           value = value !== undefined ? value : argv[++i];
@@ -133,7 +138,7 @@ function parseArgs(argv) {
       if (short === 'p') {
         const value = argv[++i];
         if (value === undefined) fail('-p requires a value');
-        flags.password = value;
+        flags.password = requirePassword(value);
         i++;
         continue;
       }

--- a/cli/test/units.test.js
+++ b/cli/test/units.test.js
@@ -4,10 +4,13 @@
  */
 
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { detectLanguage, LANGUAGE_MAP } from '../src/lang-detect.js';
 import { parseDuration, resolveExpiry } from '../src/duration.js';
 import { validateHost } from '../src/host.js';
 
+const cliPath = fileURLToPath(new URL('../bin/cloakbin.js', import.meta.url));
 let passed = 0;
 let failed = 0;
 
@@ -221,6 +224,28 @@ async function run() {
       () => validateHost('ftp://files.example.com'),
       (err) => /http:\/\/ or https:\/\//i.test(err.message),
     );
+  });
+
+  await test('empty -p password is rejected', () => {
+    let err;
+    try {
+      execFileSync(process.execPath, [cliPath, '-p', ''], {
+        input: 'secret content',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (caught) {
+      err = caught;
+    }
+    assert.ok(err, 'expected the CLI to exit non-zero');
+    assert.equal(err.status, 1);
+    assert.match(String(err.stderr), /password cannot be empty/);
+  });
+
+  await test('non-empty password is not rejected by the parser', () => {
+    const out = execFileSync(process.execPath, [cliPath, '-p', 'secret', '--help'], {
+      encoding: 'utf8',
+    });
+    assert.match(out, /Usage:/);
   });
 
   console.log(`\n${passed} passed, ${failed} failed`);


### PR DESCRIPTION
Closes #177

## Summary

Rejects an empty `-p` / `--password` value before it can be treated as no password by the crypto layer.

- Long flag: `--password ""` exits non-zero with `password cannot be empty`.
- Short flag: `-p ""` exits non-zero with the same message.
- A non-empty password still reaches normal parsing.

## Verification

- Added subprocess unit tests for `-p ""` and for a non-empty `-p secret` path.
- `node cli/test/units.test.js` passes: 35 passed, 0 failed.
- `git diff --check` passes.

Signed off with DCO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty passwords are now rejected for both long-form and short-form password options.
  * The CLI displays an appropriate error and exits when an empty password is provided.
  * Non-empty passwords continue to be accepted normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR rejects explicitly empty password arguments in both CLI password-flag branches and adds subprocess regression coverage.
- Adds a shared `requirePassword` validation helper.
- Applies validation to `-p` and `--password`.
- Tests empty short-form rejection and non-empty parser behavior.
</details>

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking gap in long-form password-flag regression coverage.

The validation correctly rejects zero-length values in both parser branches, but the subprocess tests cover only the short-form rejection path.

**Files Needing Attention:** cli/test/units.test.js

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cli/bin/cloakbin.js | Adds zero-length password validation to both long and short password parsing paths without changing non-empty password handling. |
| cli/test/units.test.js | Adds subprocess coverage for short-form rejection and non-empty parsing, but does not exercise the independently changed long-form branch. |

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acli%2Ftest%2Funits.test.js%3A229-242%0A**Cover%20the%20long%20password%20flag**%0A%0AThe%20rejection%20test%20invokes%20only%20%60-p%60%2C%20while%20%60--password%60%20uses%20a%20separate%20parser%20branch%20modified%20by%20this%20PR.%20A%20regression%20in%20the%20promised%20long-form%20behavior%20would%20therefore%20leave%20the%20new%20subprocess%20suite%20passing.%0A%0A%60%60%60suggestion%0A%20%20for%20%28const%20args%20of%20%5B%5B'-p'%2C%20''%5D%2C%20%5B'--password'%2C%20''%5D%5D%29%20%7B%0A%20%20%20%20await%20test%28%60empty%20%24%7Bargs%5B0%5D%7D%20password%20is%20rejected%60%2C%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20let%20err%3B%0A%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20execFileSync%28process.execPath%2C%20%5BcliPath%2C%20...args%5D%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20input%3A%20'secret%20content'%2C%0A%20%20%20%20%20%20%20%20%20%20stdio%3A%20%5B'pipe'%2C%20'pipe'%2C%20'pipe'%5D%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%7D%20catch%20%28caught%29%20%7B%0A%20%20%20%20%20%20%20%20err%20%3D%20caught%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20assert.ok%28err%2C%20'expected%20the%20CLI%20to%20exit%20non-zero'%29%3B%0A%20%20%20%20%20%20assert.equal%28err.status%2C%201%29%3B%0A%20%20%20%20%20%20assert.match%28String%28err.stderr%29%2C%20%2Fpassword%20cannot%20be%20empty%2F%29%3B%0A%20%20%20%20%7D%29%3B%0A%20%20%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=193&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22fix%2Freject-empty-password%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Freject-empty-password%22.%0A%0A%23%23%23%20Issue%201%0Acli%2Ftest%2Funits.test.js%3A229-242%0A**Cover%20the%20long%20password%20flag**%0A%0AThe%20rejection%20test%20invokes%20only%20%60-p%60%2C%20while%20%60--password%60%20uses%20a%20separate%20parser%20branch%20modified%20by%20this%20PR.%20A%20regression%20in%20the%20promised%20long-form%20behavior%20would%20therefore%20leave%20the%20new%20subprocess%20suite%20passing.%0A%0A%60%60%60suggestion%0A%20%20for%20%28const%20args%20of%20%5B%5B'-p'%2C%20''%5D%2C%20%5B'--password'%2C%20''%5D%5D%29%20%7B%0A%20%20%20%20await%20test%28%60empty%20%24%7Bargs%5B0%5D%7D%20password%20is%20rejected%60%2C%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20let%20err%3B%0A%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20execFileSync%28process.execPath%2C%20%5BcliPath%2C%20...args%5D%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20input%3A%20'secret%20content'%2C%0A%20%20%20%20%20%20%20%20%20%20stdio%3A%20%5B'pipe'%2C%20'pipe'%2C%20'pipe'%5D%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%7D%20catch%20%28caught%29%20%7B%0A%20%20%20%20%20%20%20%20err%20%3D%20caught%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20assert.ok%28err%2C%20'expected%20the%20CLI%20to%20exit%20non-zero'%29%3B%0A%20%20%20%20%20%20assert.equal%28err.status%2C%201%29%3B%0A%20%20%20%20%20%20assert.match%28String%28err.stderr%29%2C%20%2Fpassword%20cannot%20be%20empty%2F%29%3B%0A%20%20%20%20%7D%29%3B%0A%20%20%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=193&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Acli%2Ftest%2Funits.test.js%3A229-242%0A**Cover%20the%20long%20password%20flag**%0A%0AThe%20rejection%20test%20invokes%20only%20%60-p%60%2C%20while%20%60--password%60%20uses%20a%20separate%20parser%20branch%20modified%20by%20this%20PR.%20A%20regression%20in%20the%20promised%20long-form%20behavior%20would%20therefore%20leave%20the%20new%20subprocess%20suite%20passing.%0A%0A%60%60%60suggestion%0A%20%20for%20%28const%20args%20of%20%5B%5B'-p'%2C%20''%5D%2C%20%5B'--password'%2C%20''%5D%5D%29%20%7B%0A%20%20%20%20await%20test%28%60empty%20%24%7Bargs%5B0%5D%7D%20password%20is%20rejected%60%2C%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20let%20err%3B%0A%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20execFileSync%28process.execPath%2C%20%5BcliPath%2C%20...args%5D%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20input%3A%20'secret%20content'%2C%0A%20%20%20%20%20%20%20%20%20%20stdio%3A%20%5B'pipe'%2C%20'pipe'%2C%20'pipe'%5D%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%7D%20catch%20%28caught%29%20%7B%0A%20%20%20%20%20%20%20%20err%20%3D%20caught%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20assert.ok%28err%2C%20'expected%20the%20CLI%20to%20exit%20non-zero'%29%3B%0A%20%20%20%20%20%20assert.equal%28err.status%2C%201%29%3B%0A%20%20%20%20%20%20assert.match%28String%28err.stderr%29%2C%20%2Fpassword%20cannot%20be%20empty%2F%29%3B%0A%20%20%20%20%7D%29%3B%0A%20%20%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=193&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
cli/test/units.test.js:229-242
**Cover the long password flag**

The rejection test invokes only `-p`, while `--password` uses a separate parser branch modified by this PR. A regression in the promised long-form behavior would therefore leave the new subprocess suite passing.

```suggestion
  for (const args of [['-p', ''], ['--password', '']]) {
    await test(`empty ${args[0]} password is rejected`, () => {
      let err;
      try {
        execFileSync(process.execPath, [cliPath, ...args], {
          input: 'secret content',
          stdio: ['pipe', 'pipe', 'pipe'],
        });
      } catch (caught) {
        err = caught;
      }
      assert.ok(err, 'expected the CLI to exit non-zero');
      assert.equal(err.status, 1);
      assert.match(String(err.stderr), /password cannot be empty/);
    });
  }
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): reject empty password"](https://github.com/ishannaik/cloakbin/commit/9e0f1b2ffbfaa15261869ca385479b4b326fd295) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51192670)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->