### PR TITLE
fix: remove broken asset generation scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
 		"format": "prettier --write .",
 		"format:check": "prettier --check .",
 		"type-coverage": "svelte-kit sync && type-coverage --ignore-files \".svelte-kit/**\" --at-least 93",
-		"generate:assets": "node generate-assets.mjs && node generate-extra-assets.mjs",
-		"generate:assets:main": "node generate-assets.mjs",
-		"generate:assets:extra": "node generate-extra-assets.mjs",
 		"test": "vitest run"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Closes #181

## Summary

Removes `generate:assets`, `generate:assets:main`, and `generate:assets:extra` from `package.json`. The scripts referenced `generate-assets.mjs` and `generate-extra-assets.mjs`, neither of which exists in the repository.

The generated icons in `static/` are already committed, so no regeneration step is needed for a fresh clone.

## Verification

- `rg` confirms no remaining references to `generate:assets`, `generate-assets.mjs`, or `generate-extra-assets.mjs`.
- `git diff --check` passes.

Signed off with DCO.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Removes three nonfunctional asset-generation package scripts whose referenced generator files are absent.
- Deletes `generate:assets`, `generate:assets:main`, and `generate:assets:extra`.
- Leaves the existing development, build, validation, and test scripts unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only removes unusable package scripts with no repository callers.

The deleted scripts referenced files that are absent from the repository, while repository workflows, documentation, hooks, deployment configuration, and other package scripts do not invoke the removed commands.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | Safely removes three broken, unreferenced asset-generation scripts without changing dependencies or supported build commands. |

<sub>Reviews (1): Last reviewed commit: ["fix: remove broken asset generation scri..."](https://github.com/ishannaik/cloakbin/commit/d850db2833820c3a70f02a1b675856c40d4a5fad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51194000)</sub>

<!-- /greptile_comment -->