### PR TITLE
fix: set editor language from imported file extension

### DIFF
--- a/src/lib/languages.test.ts
+++ b/src/lib/languages.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+	detectLanguageFromFilename,
 	normalizePasteLanguage,
 	isAllowedPasteLanguage,
 	PASTE_LANGUAGE_SET,
@@ -54,5 +55,32 @@ describe('LANGUAGE_PICKER_OPTIONS', () => {
 			if (opt.value === 'auto') continue;
 			expect(PASTE_LANGUAGE_SET.has(opt.value)).toBe(true);
 		}
+	});
+});
+
+describe('detectLanguageFromFilename', () => {
+	const cases = [
+		['main.py', 'python'],
+		['script.js', 'javascript'],
+		['app.tsx', 'typescript'],
+		['style.scss', 'css'],
+		['README.md', 'markdown'],
+		['Dockerfile', 'dockerfile'],
+		['Makefile', 'makefile']
+	] as const;
+
+	it.each(cases)('maps %s to %s', (filename, expected) => {
+		expect(detectLanguageFromFilename(filename)).toBe(expected);
+	});
+
+	it('handles paths and uppercase extensions', () => {
+		expect(detectLanguageFromFilename('/tmp/src/Main.PY')).toBe('python');
+		expect(detectLanguageFromFilename('C:\\src\\App.TSX')).toBe('typescript');
+	});
+
+	it('returns null for unknown or missing extensions', () => {
+		expect(detectLanguageFromFilename('notes.txt.bak')).toBeNull();
+		expect(detectLanguageFromFilename('README')).toBeNull();
+		expect(detectLanguageFromFilename('')).toBeNull();
 	});
 });

--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -120,3 +120,80 @@ export function isAllowedPasteLanguage(language: string): boolean {
 	const canonical = LANGUAGE_ALIASES[raw] ?? raw;
 	return PASTE_LANGUAGE_SET.has(canonical);
 }
+
+/** Filename extensions → canonical paste language id. */
+const EXTENSION_LANGUAGE: Readonly<Record<string, string>> = {
+	txt: 'plaintext',
+	md: 'markdown',
+	markdown: 'markdown',
+	json: 'json',
+	js: 'javascript',
+	mjs: 'javascript',
+	cjs: 'javascript',
+	jsx: 'javascript',
+	ts: 'typescript',
+	tsx: 'typescript',
+	svelte: 'html',
+	vue: 'html',
+	py: 'python',
+	rs: 'rust',
+	go: 'go',
+	java: 'java',
+	c: 'c',
+	h: 'c',
+	cpp: 'cpp',
+	hpp: 'cpp',
+	cs: 'csharp',
+	rb: 'ruby',
+	php: 'php',
+	swift: 'swift',
+	kt: 'kotlin',
+	html: 'html',
+	htm: 'html',
+	css: 'css',
+	scss: 'css',
+	sass: 'css',
+	less: 'css',
+	xml: 'xml',
+	yaml: 'yaml',
+	yml: 'yaml',
+	toml: 'toml',
+	ini: 'ini',
+	cfg: 'ini',
+	conf: 'ini',
+	sh: 'bash',
+	bash: 'bash',
+	zsh: 'bash',
+	sql: 'sql',
+	graphql: 'graphql',
+	env: 'plaintext',
+	log: 'plaintext',
+	csv: 'plaintext',
+	dockerfile: 'dockerfile',
+	makefile: 'makefile'
+};
+
+/**
+ * Detect the language from a filename, based on its extension.
+ * Returns null when the extension is unknown so callers can keep the
+ * current selection instead of resetting it.
+ */
+export function detectLanguageFromFilename(filename: string): string | null {
+	const normalized = filename.trim().toLowerCase();
+	if (!normalized) return null;
+
+	const base = normalized.split('/').pop()?.split('\\').pop() ?? '';
+	if (!base) return null;
+
+	if (base === 'dockerfile' || base === 'makefile') {
+		return EXTENSION_LANGUAGE[base] ?? null;
+	}
+
+	const dot = base.lastIndexOf('.');
+	if (dot === -1 || dot === base.length - 1) return null;
+	const ext = base.slice(dot + 1);
+	const mapped = EXTENSION_LANGUAGE[ext] ?? LANGUAGE_ALIASES[ext];
+
+	if (!mapped || !PASTE_LANGUAGE_SET.has(mapped)) return null;
+	return mapped;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,11 @@
 	import { EditorView, keymap } from '@codemirror/view';
 	import type { Extension } from '@codemirror/state';
 	import type { LanguageSupport } from '@codemirror/language';
-	import { LANGUAGE_PICKER_OPTIONS, isAllowedPasteLanguage } from '$lib/languages';
+	import {
+		detectLanguageFromFilename,
+		LANGUAGE_PICKER_OPTIONS,
+		isAllowedPasteLanguage
+	} from '$lib/languages';
 	import {
 		dracula,
 		cobalt,
@@ -751,7 +755,9 @@
 
 <ImportModal
 	bind:open={showImportModal}
-	onImport={(text) => {
+	onImport={(text, filename) => {
 		content = text;
+		const language = detectLanguageFromFilename(filename);
+		if (language) selectedLanguage = language;
 	}}
 />


### PR DESCRIPTION
Closes #184

## Summary

Uses the filename that `ImportModal` already passes to the home page callback to set the editor language when the extension is recognized. Unknown extensions leave the current selection untouched.

- Added `detectLanguageFromFilename` with an extension map and path/uppercase handling.
- The editor language state updates on import, so highlighting changes before the user creates the paste.

## Verification

- `./node_modules/.bin/vitest run src/lib/languages.test.ts` passes (16 tests).
- `DB_TYPE=memory ./node_modules/.bin/vite build` passes.
- `svelte-check` reports 0 errors (only pre-existing warnings).
- `git diff --check` passes.

Signed off with DCO.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR derives the editor language from filenames imported through ImportModal and preserves the existing selection for unknown extensions.
- Adds an extension-to-language detector with path and case normalization.
- Updates the home-page import callback to apply detected languages.
- Adds focused filename-detection tests.
</details>

<h3>Confidence Score: 4/5</h3>

The PR needs a fix before merging because several recognized imported file types select language IDs that disable syntax highlighting.

The new detector makes unsupported language IDs reachable in the create editor, whose loader falls through to null rather than installing highlighting support.

**Files Needing Attention:** src/lib/languages.ts, src/routes/+page.svelte

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/languages.ts | Adds filename detection, but several returned language IDs have no corresponding create-editor language support. |
| src/routes/+page.svelte | Applies the detected language during ImportModal imports; the existing loader returns null for some newly reachable IDs. |
| src/lib/languages.test.ts | Covers normalization and representative mappings but does not verify that returned IDs produce editor highlighting. |

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Flib%2Flanguages.ts%3A170-171%0A**Mapped%20languages%20lose%20highlighting**%0A%0AWhen%20users%20import%20Dockerfile%2C%20Makefile%2C%20Ruby%2C%20C%23%2C%20Kotlin%2C%20Swift%2C%20Bash%2C%20INI%2C%20or%20GraphQL%20files%2C%20this%20detector%20assigns%20canonical%20IDs%20that%20%60loadLanguageExtension%60%20does%20not%20handle%2C%20causing%20the%20create%20editor%20to%20display%20no%20syntax%20highlighting%3B%20several%20of%20these%20IDs%20also%20have%20no%20matching%20language-picker%20option.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=195&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22fix%2Fimport-extension-language%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fimport-extension-language%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Flib%2Flanguages.ts%3A170-171%0A**Mapped%20languages%20lose%20highlighting**%0A%0AWhen%20users%20import%20Dockerfile%2C%20Makefile%2C%20Ruby%2C%20C%23%2C%20Kotlin%2C%20Swift%2C%20Bash%2C%20INI%2C%20or%20GraphQL%20files%2C%20this%20detector%20assigns%20canonical%20IDs%20that%20%60loadLanguageExtension%60%20does%20not%20handle%2C%20causing%20the%20create%20editor%20to%20display%20no%20syntax%20highlighting%3B%20several%20of%20these%20IDs%20also%20have%20no%20matching%20language-picker%20option.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=195&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Flib%2Flanguages.ts%3A170-171%0A**Mapped%20languages%20lose%20highlighting**%0A%0AWhen%20users%20import%20Dockerfile%2C%20Makefile%2C%20Ruby%2C%20C%23%2C%20Kotlin%2C%20Swift%2C%20Bash%2C%20INI%2C%20or%20GraphQL%20files%2C%20this%20detector%20assigns%20canonical%20IDs%20that%20%60loadLanguageExtension%60%20does%20not%20handle%2C%20causing%20the%20create%20editor%20to%20display%20no%20syntax%20highlighting%3B%20several%20of%20these%20IDs%20also%20have%20no%20matching%20language-picker%20option.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=195&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/lib/languages.ts:170-171
**Mapped languages lose highlighting**

When users import Dockerfile, Makefile, Ruby, C#, Kotlin, Swift, Bash, INI, or GraphQL files, this detector assigns canonical IDs that `loadLanguageExtension` does not handle, causing the create editor to display no syntax highlighting; several of these IDs also have no matching language-picker option.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: set editor language from imported f..."](https://github.com/ishannaik/cloakbin/commit/f3829cc208d0512fcfe1a647eeb949bd781ce2f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51194972)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->