### PR TITLE
docs: add DB_TYPE to env block

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ so the gate fails below 93%.
 ## Environment Variables
 
 ```env
+# DB_TYPE=memory needs no database and is the fastest way to run the project locally.
+# DB_TYPE=mongodb requires MONGODB_URI below.
+DB_TYPE=memory
 MONGODB_URI=mongodb://localhost:27017/cloakbin
 ADMIN_USER=admin
 ADMIN_PASS=your-secure-password


### PR DESCRIPTION
Closes #179

## Summary

Adds `DB_TYPE` to the README environment block with its accepted values, and clarifies that `DB_TYPE=memory` needs no database while `DB_TYPE=mongodb` requires `MONGODB_URI`.

## Verification

- Matches the accepted values and error text in `src/lib/db/index.ts`.
- `git diff --check` passes.

Docs-only change.

Signed off with DCO.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds `DB_TYPE` to the README environment-variable example and explains the database requirements of its memory and MongoDB modes.
- Documents `memory` as the local-development option.
- Documents that `mongodb` requires `MONGODB_URI`.
- Leaves the copyable `.env.example` used by Quick Start without the required variable.
</details>

<h3>Confidence Score: 4/5</h3>

The documentation should be corrected before merging because the prescribed Quick Start still creates an environment file that fails application initialization.

The README accurately describes the database modes, but users following its setup flow copy an `.env.example` without the now-required `DB_TYPE`, causing initialization to throw.

**Files Needing Attention:** README.md and .env.example

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | The new database-mode guidance matches runtime behavior, but it does not update the configuration template that the Quick Start tells users to copy. |

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0AREADME.md%3A137%0A**Quick%20Start%20omits%20required%20DB_TYPE**%0A%0AWhen%20a%20new%20user%20follows%20the%20Quick%20Start%20and%20copies%20%60.env.example%60%2C%20the%20resulting%20environment%20lacks%20%60DB_TYPE%60%2C%20causing%20database%20initialization%20to%20throw%20%60DB_TYPE%20environment%20variable%20is%20required%60%20instead%20of%20starting%20the%20application.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22docs%2Fenv-block-db-type%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fenv-block-db-type%22.%0A%0A%23%23%23%20Issue%201%0AREADME.md%3A137%0A**Quick%20Start%20omits%20required%20DB_TYPE**%0A%0AWhen%20a%20new%20user%20follows%20the%20Quick%20Start%20and%20copies%20%60.env.example%60%2C%20the%20resulting%20environment%20lacks%20%60DB_TYPE%60%2C%20causing%20database%20initialization%20to%20throw%20%60DB_TYPE%20environment%20variable%20is%20required%60%20instead%20of%20starting%20the%20application.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0AREADME.md%3A137%0A**Quick%20Start%20omits%20required%20DB_TYPE**%0A%0AWhen%20a%20new%20user%20follows%20the%20Quick%20Start%20and%20copies%20%60.env.example%60%2C%20the%20resulting%20environment%20lacks%20%60DB_TYPE%60%2C%20causing%20database%20initialization%20to%20throw%20%60DB_TYPE%20environment%20variable%20is%20required%60%20instead%20of%20starting%20the%20application.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:137
**Quick Start omits required DB_TYPE**

When a new user follows the Quick Start and copies `.env.example`, the resulting environment lacks `DB_TYPE`, causing database initialization to throw `DB_TYPE environment variable is required` instead of starting the application.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add DB\_TYPE to env block"](https://github.com/ishannaik/cloakbin/commit/9b2b6cd3365141f3f50494e46006a1d3de2205d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51195243)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->