### PR TITLE
fix: return JSON from CSRF rejections

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -207,11 +207,23 @@ export const handle: Handle = async ({ event, resolve }) => {
 				const originHost = new URL(origin).host;
 				if (originHost !== host) {
 					console.warn(`CSRF blocked: origin=${origin}, host=${host}`);
-					return new Response('Forbidden - CSRF protection', { status: 403 });
+					return new Response(
+						JSON.stringify({ error: 'CSRF protection failed: origin does not match host' }),
+						{
+							status: 403,
+							headers: { 'Content-Type': 'application/json' }
+						}
+					);
 				}
 			} catch {
 				// Invalid origin URL
-				return new Response('Forbidden - Invalid origin', { status: 403 });
+				return new Response(
+					JSON.stringify({ error: 'CSRF protection failed: invalid origin' }),
+					{
+						status: 403,
+						headers: { 'Content-Type': 'application/json' }
+					}
+				);
 			}
 		}
 
@@ -224,7 +236,13 @@ export const handle: Handle = async ({ event, resolve }) => {
 					const refererHost = new URL(referer).host;
 					if (refererHost !== host) {
 						console.warn(`CSRF blocked: referer=${referer}, host=${host}`);
-						return new Response('Forbidden - CSRF protection', { status: 403 });
+						return new Response(
+							JSON.stringify({ error: 'CSRF protection failed: referer does not match host' }),
+							{
+								status: 403,
+								headers: { 'Content-Type': 'application/json' }
+							}
+						);
 					}
 				} catch {
 					// Invalid referer URL - allow (some privacy tools strip referer)

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -435,7 +435,13 @@
 			});
 
 			if (!res.ok) {
-				const error = await res.text();
+				const raw = await res.text();
+				let error = raw;
+				try {
+					error = JSON.parse(raw).error ?? raw;
+				} catch {
+					// plain-text errors stay as-is
+				}
 				throw new Error(error || 'Failed to create paste');
 			}
 


### PR DESCRIPTION
Closes #182

## Summary

Returns `{ error: string }` with `Content-Type: application/json` from all CSRF rejection paths in `src/hooks.server.ts`:

- origin mismatch -> `CSRF protection failed: origin does not match host`
- invalid origin -> `CSRF protection failed: invalid origin`
- referer mismatch -> `CSRF protection failed: referer does not match host`

Status remains `403`.

## Verification

- `svelte-check` reports 0 errors (only pre-existing warnings).
- `DB_TYPE=memory ./node_modules/.bin/vite build` passes.
- `git diff --check` passes.

Signed off with DCO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses for blocked requests by returning structured JSON while preserving the appropriate forbidden status.
  * Enhanced paste-creation error messages by displaying meaningful details from both JSON and plain-text responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes CSRF rejection responses to return structured JSON while retaining status 403, and updates paste creation to extract readable messages from JSON errors with a plain-text fallback.
- Returns `{ error: string }` with `Content-Type: application/json` for all three CSRF rejection paths.
- Parses failed paste-creation responses so JSON errors display as readable messages.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/hooks.server.ts | Converts origin and referer CSRF rejection bodies from plain text to consistent JSON responses without changing rejection conditions or status codes. |
| src/routes/+page.svelte | Completes the prior review fix by extracting the string error from JSON responses while retaining plain-text and empty-body fallbacks. |

<sub>Reviews (2): Last reviewed commit: ["fix: decode JSON errors in paste creatio..."](https://github.com/ishannaik/cloakbin/commit/4b19ef52067e391c488f3e068720f49989b5a99a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51198401)</sub>

<!-- /greptile_comment -->