### PR TITLE
fix: disable password decrypt button when empty

### DIFF
--- a/src/routes/p/[id]/+page.svelte
+++ b/src/routes/p/[id]/+page.svelte
@@ -679,7 +679,8 @@
 				/>
 				<button
 					onclick={decryptWithPassword}
-					class="w-full px-4 py-2 bg-teal-500 text-zinc-900 rounded font-medium hover:bg-teal-400"
+					disabled={!passwordInput.trim()}
+					class="w-full px-4 py-2 bg-teal-500 text-zinc-900 rounded font-medium hover:bg-teal-400 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-teal-500"
 				>
 					Decrypt
 				</button>


### PR DESCRIPTION
Closes #186.

## Summary
The password Decrypt button now behaves like the manual-key button: it stays disabled while the field is empty or whitespace and enables as soon as a character is typed.

## Changes
- Adds `disabled={!passwordInput.trim()}` to the password Decrypt button.
- Uses the same visible disabled styles as the key screen (`disabled:opacity-50`, `disabled:cursor-not-allowed`).

## Verification
- `pnpm check`: 0 errors.
- `pnpm test`: 47 passed.
- Note: repo-wide `format:check` currently reports pre-existing formatting issues across many files, including this one on `main`; this PR keeps the diff to the single behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the decrypt button when no password is entered.
  * Prevented interaction and hover effects while the button is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR aligns the password Decrypt button with the handler’s existing input validation.
- Disables the button while the password field is empty or whitespace-only.
- Adds visible disabled and hover styles consistent with the manual-key flow.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The button’s new disabled condition matches the decrypt handler’s existing guard, and no changed-code path introduces incorrect decryption behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/p/[id]/+page.svelte | Adds disabled-state behavior and styling to the password Decrypt button without changing the underlying decryption contract. |

<sub>Reviews (1): Last reviewed commit: ["fix: disable password decrypt button whe..."](https://github.com/ishannaik/cloakbin/commit/19a66fd93905ee291229f0d0a98b196fc5125bc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51473319)</sub>

<!-- /greptile_comment -->