### PR TITLE
fix: close settings dropdown on escape

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -365,6 +365,12 @@
 
 	// Global keyboard shortcuts handler
 	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape' && showSettings) {
+			showSettings = false;
+			document.getElementById('settings-button')?.focus();
+			return;
+		}
+
 		// Show shortcuts modal on ? or Ctrl+/
 		if (e.key === '?' || ((e.ctrlKey || e.metaKey) && e.key === '/')) {
 			e.preventDefault();
@@ -544,6 +550,7 @@
 			<!-- Settings dropdown -->
 			<div class="relative settings-dropdown">
 				<button
+					id="settings-button"
 					onclick={() => showSettings = !showSettings}
 					class="p-2 sm:p-2.5 bg-zinc-700 hover:bg-zinc-600 text-zinc-100 rounded font-medium transition-all duration-150 active:scale-95"
 					title="Settings"


### PR DESCRIPTION
Closes #185.

## Summary
Escape now closes the settings dropdown when it is open and returns focus to the settings button, so keyboard users can dismiss the panel without reaching for the mouse.

## Changes
- Handles `Escape` in the existing global `handleKeydown`.
- Adds `id="settings-button"` to the settings toggle so focus can return after close.
- Leaves all existing shortcuts untouched.

## Verification
- `pnpm check`: 0 errors (8 pre-existing warnings).
- `pnpm test`: 47 passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Escape now closes the settings dropdown and restores focus to its toggle button.
- Adds an early Escape-key branch to the existing global keyboard handler.
- Adds a stable ID to the settings button for focus restoration.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The settings dropdown closes only when open, focus returns to the settings button, and the handler does not prevent other active UI layers from processing Escape independently.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/+page.svelte | The new Escape behavior is correctly scoped to an open settings dropdown, preserves existing shortcuts, and restores keyboard focus without introducing an identified failure. |

<sub>Reviews (1): Last reviewed commit: ["fix: close settings dropdown on escape"](https://github.com/ishannaik/cloakbin/commit/18da92ca3f61a7bf80f171fec01f0c09c6751534) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51474463)</sub>

<!-- /greptile_comment -->