### PR TITLE
docs: add DB_TYPE to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Storage adapter: memory (no database, data lost on restart) or mongodb (requires MONGODB_URI below).
-# DB_TYPE=memory
+DB_TYPE=memory
 
 MONGODB_URI=mongodb+srv://username:***@cluster.mongodb.net/?retryWrites=true&w=majority
 

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Storage adapter: memory (no database, data lost on restart) or mongodb (requires MONGODB_URI below).
+# DB_TYPE=memory
+
 MONGODB_URI=mongodb+srv://username:***@cluster.mongodb.net/?retryWrites=true&w=majority
 
 # Admin Panel


### PR DESCRIPTION
Closes #198.

## Summary
Adds `DB_TYPE` to `.env.example` so a fresh clone can follow the Quick Start without hitting the `DB_TYPE environment variable is required` error.

## Changes
- Documents `memory` (no database, data lost on restart) and `mongodb` (requires `MONGODB_URI`).

## Verification
- Docs-only change.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an active `DB_TYPE=memory` default so fresh-clone Quick Start users can start the application without configuring MongoDB.

- Documents the available `memory` and `mongodb` storage adapters.
- Notes that memory-backed data is lost on restart and MongoDB requires `MONGODB_URI`.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .env.example | Adds an uncommented memory-storage default, resolving the previously reported missing `DB_TYPE` startup configuration. |

<sub>Reviews (2): Last reviewed commit: ["docs: set memory as default storage in e..."](https://github.com/ishannaik/cloakbin/commit/577f45e9bfa7caf390f2aa196d5b33862babc836) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51474803)</sub>

<!-- /greptile_comment -->