### PR TITLE
feat: add touch-friendly select all button

### DIFF
--- a/src/routes/p/[id]/+page.svelte
+++ b/src/routes/p/[id]/+page.svelte
@@ -20,7 +20,7 @@
 	} from 'thememirror';
 	import { EditorView } from '@codemirror/view';
 	import logo from '$lib/assets/logo.svg';
-	import { Lock, Copy, Plus, Check, Files, Share2, Key, Flame, Settings } from 'lucide-svelte';
+	import { Lock, Copy, Plus, Check, Files, Share2, Key, Flame, Settings, TextSelect } from 'lucide-svelte';
 	import ShortcutsModal from '$lib/components/ShortcutsModal.svelte';
 
 	// OS detection for keyboard shortcut display
@@ -40,6 +40,7 @@
 	let encryptedContent = $state(''); // Store encrypted content for manual key entry
 	let pasteMetadata = $state<{ createdAt: string; expiresAt: string } | null>(null);
 	let passwordInput = $state('');
+	let selectAllAnnouncement = $state('');
 	let showBurnWarning = $state(false);
 	let pasteData = $state<{ content: string; hasPassword: boolean; salt?: string; burnAfterRead: boolean; createdAt: string; expiresAt: string; language?: string } | null>(null);
 	let detectedLanguage = $state('javascript');
@@ -289,6 +290,7 @@
 			const selection = window.getSelection();
 			selection?.removeAllRanges();
 			selection?.addRange(range);
+			selectAllAnnouncement = 'Content selected';
 		}
 	}
 
@@ -531,6 +533,7 @@
 		</a>
 
 		{#if viewState === 'success'}
+			<span aria-live="polite" class="sr-only">{selectAllAnnouncement}</span>
 			<div class="flex items-center gap-1 sm:gap-2">
 				<button
 					onclick={copyToClipboard}
@@ -543,6 +546,15 @@
 						<Copy size={16} />
 						<span class="hidden sm:inline">Copy</span>
 					{/if}
+				</button>
+				<button
+					onclick={selectAllContent}
+					aria-label="Select all"
+					title="Select all"
+					class="h-9 sm:h-10 p-2 sm:px-3 bg-zinc-700 hover:bg-zinc-600 text-zinc-100 rounded font-medium transition-all duration-150 active:scale-95 flex items-center gap-2"
+				>
+					<TextSelect size={16} />
+					<span class="hidden sm:inline">Select all</span>
 				</button>
 				<button
 					onclick={duplicatePaste}


### PR DESCRIPTION
Closes #171.

## Summary
Adds a touch-friendly Select all button to the paste view header that runs the existing `selectAllContent()` and announces the result through a polite `aria-live` region.

## Changes
- Adds a Select all button with a 36/40px touch target in the success-state header group.
- Uses `TextSelect` icon and an `aria-label` for icon-only mobile layout.
- Sets a `Content selected` announcement in the existing select-all handler.
- Adds a visually hidden `aria-live="polite"` region in the success block.

## Verification
- `pnpm check`: 0 errors (8 pre-existing warnings).
- `pnpm test`: 47 passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a touch-friendly Select all action and an assistive-technology announcement to the successful paste view.
- Adds a responsive TextSelect button that invokes the existing selection handler.
- Adds a polite live region and updates it after successful selection.
- The new interaction has gaps around repeated announcements and the asynchronously mounted editor target.
</details>

<h3>Confidence Score: 3/5</h3>

The repeated accessibility announcement and early-click selection failures should be fixed before merging.

The live region stops providing feedback after its first identical update, and the enabled button can invoke the selection handler while LazyCodeMirror still lacks the required `.cm-content` target.

**Files Needing Attention:** src/routes/p/[id]/+page.svelte

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/p/[id]/+page.svelte | Adds the Select all control and live announcement, but repeated activations are not re-announced and early clicks can silently fail before CodeMirror mounts. |

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Froutes%2Fp%2F%5Bid%5D%2F%2Bpage.svelte%3A290%0A**Repeated%20selections%20are%20not%20announced**%0A%0AWhen%20a%20screen-reader%20user%20activates%20Select%20all%20more%20than%20once%20while%20the%20success%20view%20remains%20mounted%2C%20%60selectAllAnnouncement%60%20is%20reassigned%20the%20already-rendered%20text%2C%20so%20the%20live%20region%20provides%20no%20confirmation%20after%20the%20first%20selection.%0A%0A%23%23%23%20Issue%202%0Asrc%2Froutes%2Fp%2F%5Bid%5D%2F%2Bpage.svelte%3A547-548%0A**Selection%20target%20is%20not%20ready**%0A%0AWhen%20the%20success%20view%20still%20displays%20%60LazyCodeMirror%60's%20loading%20placeholder%2C%20this%20enabled%20button%20calls%20%60selectAllContent%28%29%60%20before%20%60.cm-content%60%20exists%2C%20causing%20the%20click%20to%20produce%20neither%20a%20selection%20nor%20an%20announcement.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=203&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22feat%2Fselect-all-button%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fselect-all-button%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Froutes%2Fp%2F%5Bid%5D%2F%2Bpage.svelte%3A290%0A**Repeated%20selections%20are%20not%20announced**%0A%0AWhen%20a%20screen-reader%20user%20activates%20Select%20all%20more%20than%20once%20while%20the%20success%20view%20remains%20mounted%2C%20%60selectAllAnnouncement%60%20is%20reassigned%20the%20already-rendered%20text%2C%20so%20the%20live%20region%20provides%20no%20confirmation%20after%20the%20first%20selection.%0A%0A%23%23%23%20Issue%202%0Asrc%2Froutes%2Fp%2F%5Bid%5D%2F%2Bpage.svelte%3A547-548%0A**Selection%20target%20is%20not%20ready**%0A%0AWhen%20the%20success%20view%20still%20displays%20%60LazyCodeMirror%60's%20loading%20placeholder%2C%20this%20enabled%20button%20calls%20%60selectAllContent%28%29%60%20before%20%60.cm-content%60%20exists%2C%20causing%20the%20click%20to%20produce%20neither%20a%20selection%20nor%20an%20announcement.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=203&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Froutes%2Fp%2F%5Bid%5D%2F%2Bpage.svelte%3A290%0A**Repeated%20selections%20are%20not%20announced**%0A%0AWhen%20a%20screen-reader%20user%20activates%20Select%20all%20more%20than%20once%20while%20the%20success%20view%20remains%20mounted%2C%20%60selectAllAnnouncement%60%20is%20reassigned%20the%20already-rendered%20text%2C%20so%20the%20live%20region%20provides%20no%20confirmation%20after%20the%20first%20selection.%0A%0A%23%23%23%20Issue%202%0Asrc%2Froutes%2Fp%2F%5Bid%5D%2F%2Bpage.svelte%3A547-548%0A**Selection%20target%20is%20not%20ready**%0A%0AWhen%20the%20success%20view%20still%20displays%20%60LazyCodeMirror%60's%20loading%20placeholder%2C%20this%20enabled%20button%20calls%20%60selectAllContent%28%29%60%20before%20%60.cm-content%60%20exists%2C%20causing%20the%20click%20to%20produce%20neither%20a%20selection%20nor%20an%20announcement.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=203&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/routes/p/[id]/+page.svelte:290
**Repeated selections are not announced**

When a screen-reader user activates Select all more than once while the success view remains mounted, `selectAllAnnouncement` is reassigned the already-rendered text, so the live region provides no confirmation after the first selection.

### Issue 2
src/routes/p/[id]/+page.svelte:547-548
**Selection target is not ready**

When the success view still displays `LazyCodeMirror`'s loading placeholder, this enabled button calls `selectAllContent()` before `.cm-content` exists, causing the click to produce neither a selection nor an announcement.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add touch-friendly select all butt..."](https://github.com/ishannaik/cloakbin/commit/22c1aa24a465b63e62dca5861ad5725791f55fe4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51475001)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->