### PR TITLE
feat: add password reveal toggle

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,7 +24,7 @@
 		noctisLilac
 	} from 'thememirror';
 	import { spring } from 'svelte/motion';
-	import { Lock, Files, Upload, WifiOff, Settings, FileUp } from 'lucide-svelte';
+	import { Lock, Files, Upload, WifiOff, Settings, FileUp, Eye, EyeOff } from 'lucide-svelte';
 	import { goto, afterNavigate } from '$app/navigation';
 	import { onMount, onDestroy, tick } from 'svelte';
 	import { generateKey, encrypt, keyToBase64, generateSalt, deriveKeyFromPassword } from '$lib/crypto';
@@ -135,6 +135,7 @@
 	let isOffline = $state(false);
 	let usePassword = $state(false);
 	let password = $state('');
+	let showPassword = $state(false);
 	let burnAfterRead = $state(false);
 	let selectedLanguage = $state('auto'); // 'auto' means auto-detect language using highlight.js
 
@@ -657,13 +658,27 @@
 			<span class="text-zinc-400 text-sm hidden sm:inline">Password</span>
 		</label>
 		{#if usePassword}
-			<input
-				type="password"
-				bind:value={password}
-				placeholder="Password..."
-				maxlength={128}
-				class="bg-bg-secondary border border-zinc-700 rounded px-2 py-2 text-sm w-24 sm:w-32 focus:outline-none focus:border-teal-500"
-			/>
+			<div class="relative">
+				<input
+					type={showPassword ? 'text' : 'password'}
+					bind:value={password}
+					placeholder="Password..."
+					maxlength={128}
+					class="bg-bg-secondary border border-zinc-700 rounded px-2 py-2 pr-9 text-sm w-24 sm:w-32 focus:outline-none focus:border-teal-500"
+				/>
+				<button
+					type="button"
+					onclick={() => (showPassword = !showPassword)}
+					aria-label={showPassword ? 'Hide password' : 'Show password'}
+					class="absolute right-1 top-1/2 -translate-y-1/2 p-1.5 text-zinc-400 hover:text-zinc-200"
+				>
+					{#if showPassword}
+						<EyeOff size={16} />
+					{:else}
+						<Eye size={16} />
+					{/if}
+				</button>
+			</div>
 		{/if}
 		<!-- Burn toggle -->
 		<label class="relative flex items-center gap-1.5 cursor-pointer group">


### PR DESCRIPTION
Closes #166.

## Summary
Adds an eye toggle to the create-page password field so users can verify the exact password before creating the paste.

## Changes
- Adds `showPassword` state and swaps the input between `type="password"` and `type="text"`.
- Uses `Eye`/`EyeOff` icons from lucide-svelte.
- Sets a dynamic `aria-label` (`Show password` / `Hide password`).
- Keeps `bind:value` intact so typed content survives toggling.

## Verification
- `pnpm check`: 0 errors (8 pre-existing warnings).
- `pnpm test`: 47 passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an accessible password-visibility toggle to the create-page password field while retaining the bound password value.
- Introduces component-level reveal state.
- Switches the input between password and text types.
- Adds Eye and EyeOff icons with dynamic accessible labels.
</details>

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking concern that re-enabling password protection can redisplay a retained password in plaintext.

The toggle works as intended during normal use, but showPassword outlives the conditional password controls and can restore the input in its revealed state.

**Files Needing Attention:** src/routes/+page.svelte

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/+page.svelte | Adds the password reveal control, but its reveal state is not reset when password protection is disabled and re-enabled. |

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Froutes%2F%2Bpage.svelte%3A663%0A**Reveal%20state%20survives%20re-enabling**%0A%0AAfter%20a%20user%20reveals%20a%20populated%20password%2C%20unchecking%20and%20rechecking%20Password%20recreates%20the%20input%20with%20the%20retained%20%60showPassword%60%20state%2C%20displaying%20the%20retained%20password%20in%20plaintext%20without%20a%20new%20reveal%20action.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=204&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22feat%2Fpassword-reveal-toggle%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpassword-reveal-toggle%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Froutes%2F%2Bpage.svelte%3A663%0A**Reveal%20state%20survives%20re-enabling**%0A%0AAfter%20a%20user%20reveals%20a%20populated%20password%2C%20unchecking%20and%20rechecking%20Password%20recreates%20the%20input%20with%20the%20retained%20%60showPassword%60%20state%2C%20displaying%20the%20retained%20password%20in%20plaintext%20without%20a%20new%20reveal%20action.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=204&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Froutes%2F%2Bpage.svelte%3A663%0A**Reveal%20state%20survives%20re-enabling**%0A%0AAfter%20a%20user%20reveals%20a%20populated%20password%2C%20unchecking%20and%20rechecking%20Password%20recreates%20the%20input%20with%20the%20retained%20%60showPassword%60%20state%2C%20displaying%20the%20retained%20password%20in%20plaintext%20without%20a%20new%20reveal%20action.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=204&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/routes/+page.svelte:663
**Reveal state survives re-enabling**

After a user reveals a populated password, unchecking and rechecking Password recreates the input with the retained `showPassword` state, displaying the retained password in plaintext without a new reveal action.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add password reveal toggle"](https://github.com/ishannaik/cloakbin/commit/7c46c3ced1a83e94ad4cfaf159205925260d06a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51475154)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->