### PR TITLE
feat: add content size counter to editor

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -137,6 +137,22 @@
 	let password = $state('');
 	let burnAfterRead = $state(false);
 	let selectedLanguage = $state('auto'); // 'auto' means auto-detect language using highlight.js
+	const MAX_CONTENT_BYTES = 10 * 1024 * 1024;
+	let contentBytes = $derived(new Blob([content]).size);
+	let contentLabel = $derived(formatBytes(contentBytes));
+	let sizeTone = $derived(
+		contentBytes >= MAX_CONTENT_BYTES * 0.8
+			? 'text-red-400'
+			: contentBytes >= MAX_CONTENT_BYTES * 0.6
+				? 'text-amber-400'
+				: 'text-zinc-400'
+	);
+
+	function formatBytes(bytes: number): string {
+		if (bytes < 1024) return `${bytes} chars`;
+		if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+	}
 
 	// Available languages for manual selection (shared allowlist)
 	const languages = LANGUAGE_PICKER_OPTIONS;
@@ -645,6 +661,7 @@
 
 	<!-- Bottom bar -->
 	<div class="flex flex-wrap items-center justify-center gap-2 sm:gap-4 px-4 py-3 sm:py-4 border-t border-zinc-800">
+		<span class="text-xs font-mono {sizeTone}" aria-label="Content size">{contentLabel}</span>
 		<ExpirySelect bind:value={expiry} options={expiryOptions} />
 		<!-- Password toggle -->
 		<label class="flex items-center gap-1.5 cursor-pointer">


### PR DESCRIPTION
Closes #152.

## Summary
Adds a reactive size counter to the home editor bottom bar so users can see how close a paste is to the server limit while typing.

## Changes
- Shows the current content size as `chars`, `KB`, or `MB` using `new Blob([content]).size`.
- Uses the server default of 10 MiB as the reference limit.
- Turns amber at 60% and red at 80% of the limit.
- Updates reactively as `content` changes.

## Verification
- `pnpm check`: 0 errors (8 pre-existing warnings).
- `pnpm test`: 47 passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a reactive content-size indicator to the editor’s bottom bar.
- Measures the editor content and formats it as characters, KB, or MB.
- Changes the indicator color at 60% and 80% of a hard-coded 10 MiB reference limit.
- The displayed plaintext size does not match the configurable ciphertext limit enforced by the API.
</details>

<h3>Confidence Score: 4/5</h3>

The PR should be corrected before merging because the new indicator can show a paste as within the limit even when the API will reject it.

The UI measures plaintext against a fixed 10 MiB value, whereas submission encrypts and base64-encodes the content and the server validates that transformed value against a configurable limit; repeated full-content Blob construction also adds non-blocking responsiveness overhead.

**Files Needing Attention:** src/routes/+page.svelte

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/+page.svelte | Adds the reactive size display, but compares the wrong representation and fixed limit while also performing full-content allocation on reactive updates. |

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Froutes%2F%2Bpage.svelte%3A140-141%0A**Counter%20tracks%20the%20wrong%20payload**%0A%0AWhen%20incompressible%20content%20expands%20during%20encryption%20and%20base64%20encoding%2C%20this%20counter%20still%20compares%20the%20plaintext%20size%20with%2010%20MiB%20even%20though%20the%20API%20validates%20the%20encoded%20ciphertext%2C%20causing%20the%20server%20to%20reject%20a%20paste%20while%20the%20indicator%20shows%20it%20below%20the%20limit.%20A%20configured%20%60MAX_PASTE_BYTES%60%20other%20than%2010%20MiB%20also%20leaves%20these%20thresholds%20out%20of%20sync%20with%20the%20server.%0A%0A%23%23%23%20Issue%202%0Asrc%2Froutes%2F%2Bpage.svelte%3A141%0A**Counter%20reallocates%20the%20full%20content**%0A%0AConstructing%20a%20%60Blob%60%20from%20the%20complete%20value%20on%20every%20reactive%20update%20adds%20O%28n%29%20encoding%20and%20allocation%20work%20while%20editing%20large%20documents%20and%20during%20each%20encryption-animation%20frame%2C%20increasing%20main-thread%20and%20garbage-collection%20pressure%20for%20a%20passive%20status%20indicator.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=205&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22feat%2Fcontent-size-counter%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcontent-size-counter%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Froutes%2F%2Bpage.svelte%3A140-141%0A**Counter%20tracks%20the%20wrong%20payload**%0A%0AWhen%20incompressible%20content%20expands%20during%20encryption%20and%20base64%20encoding%2C%20this%20counter%20still%20compares%20the%20plaintext%20size%20with%2010%20MiB%20even%20though%20the%20API%20validates%20the%20encoded%20ciphertext%2C%20causing%20the%20server%20to%20reject%20a%20paste%20while%20the%20indicator%20shows%20it%20below%20the%20limit.%20A%20configured%20%60MAX_PASTE_BYTES%60%20other%20than%2010%20MiB%20also%20leaves%20these%20thresholds%20out%20of%20sync%20with%20the%20server.%0A%0A%23%23%23%20Issue%202%0Asrc%2Froutes%2F%2Bpage.svelte%3A141%0A**Counter%20reallocates%20the%20full%20content**%0A%0AConstructing%20a%20%60Blob%60%20from%20the%20complete%20value%20on%20every%20reactive%20update%20adds%20O%28n%29%20encoding%20and%20allocation%20work%20while%20editing%20large%20documents%20and%20during%20each%20encryption-animation%20frame%2C%20increasing%20main-thread%20and%20garbage-collection%20pressure%20for%20a%20passive%20status%20indicator.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=205&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Froutes%2F%2Bpage.svelte%3A140-141%0A**Counter%20tracks%20the%20wrong%20payload**%0A%0AWhen%20incompressible%20content%20expands%20during%20encryption%20and%20base64%20encoding%2C%20this%20counter%20still%20compares%20the%20plaintext%20size%20with%2010%20MiB%20even%20though%20the%20API%20validates%20the%20encoded%20ciphertext%2C%20causing%20the%20server%20to%20reject%20a%20paste%20while%20the%20indicator%20shows%20it%20below%20the%20limit.%20A%20configured%20%60MAX_PASTE_BYTES%60%20other%20than%2010%20MiB%20also%20leaves%20these%20thresholds%20out%20of%20sync%20with%20the%20server.%0A%0A%23%23%23%20Issue%202%0Asrc%2Froutes%2F%2Bpage.svelte%3A141%0A**Counter%20reallocates%20the%20full%20content**%0A%0AConstructing%20a%20%60Blob%60%20from%20the%20complete%20value%20on%20every%20reactive%20update%20adds%20O%28n%29%20encoding%20and%20allocation%20work%20while%20editing%20large%20documents%20and%20during%20each%20encryption-animation%20frame%2C%20increasing%20main-thread%20and%20garbage-collection%20pressure%20for%20a%20passive%20status%20indicator.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=205&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/routes/+page.svelte:140-141
**Counter tracks the wrong payload**

When incompressible content expands during encryption and base64 encoding, this counter still compares the plaintext size with 10 MiB even though the API validates the encoded ciphertext, causing the server to reject a paste while the indicator shows it below the limit. A configured `MAX_PASTE_BYTES` other than 10 MiB also leaves these thresholds out of sync with the server.

### Issue 2
src/routes/+page.svelte:141
**Counter reallocates the full content**

Constructing a `Blob` from the complete value on every reactive update adds O(n) encoding and allocation work while editing large documents and during each encryption-animation frame, increasing main-thread and garbage-collection pressure for a passive status indicator.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add content size counter to editor"](https://github.com/ishannaik/cloakbin/commit/eaf8b979d1d41f8317d523471193d149d5a2fa14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51475356)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->