### PR TITLE
feat: add copy button to raw view

### DIFF
--- a/src/routes/r/[id]/+page.svelte
+++ b/src/routes/r/[id]/+page.svelte
@@ -1,13 +1,18 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import { decrypt, base64ToKey } from '$lib/crypto';
+	import { Copy, Check } from 'lucide-svelte';
 
 	let content = $state('');
 	let viewState = $state<'loading' | 'error' | 'success' | 'needKey'>('loading');
 	let errorMessage = $state('');
 	let fullViewHref = $state('');
+	let copied = $state(false);
+	let copyTimer: ReturnType<typeof setTimeout>;
+
+	onDestroy(() => clearTimeout(copyTimer));
 
 	onMount(async () => {
 		try {
@@ -49,6 +54,17 @@
 		sessionStorage.setItem('cloakbin_duplicate', content);
 		goto('/');
 	}
+
+	async function copyContent() {
+		try {
+			await navigator.clipboard.writeText(content);
+			copied = true;
+			clearTimeout(copyTimer);
+			copyTimer = setTimeout(() => (copied = false), 2000);
+		} catch {
+			// Clipboard can be unavailable in some embedded contexts; leave the button idle.
+		}
+	}
 </script>
 
 <svelte:head>
@@ -64,6 +80,15 @@
 		<a href={fullViewHref}>Full view</a>
 		<button type="button" onclick={editAsNew}>Edit as new</button>
 	</div>
+	<button type="button" onclick={copyContent} class="copy-button" aria-label="Copy raw content">
+		{#if copied}
+			<Check size={16} />
+			<span>Copied</span>
+		{:else}
+			<Copy size={16} />
+			<span>Copy</span>
+		{/if}
+	</button>
 	<pre class="raw-content">{content}</pre>
 {/if}
 
@@ -86,6 +111,23 @@
 		word-wrap: break-word;
 		min-height: 100vh;
 		box-sizing: border-box;
+	}
+
+	.copy-button {
+		position: fixed;
+		top: 16px;
+		right: 16px;
+		z-index: 10;
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 8px 12px;
+		color: #111318;
+		background: #5eead4;
+		border: 0;
+		border-radius: 6px;
+		font: 600 13px system-ui, sans-serif;
+		cursor: pointer;
 	}
 
 	.raw-actions {


### PR DESCRIPTION
Closes #165.

## Summary
Adds a floating Copy button to the raw view that writes the full decrypted content to the clipboard and shows a two-second Copied confirmation.

## Changes
- Shows the button only in the success state.
- Copies with `navigator.clipboard.writeText(content)`.
- Swaps to a Check icon and Copied label for 2 seconds.
- Clears the reset timeout on component destroy.

## Verification
- `pnpm check`: 0 errors (8 pre-existing warnings).
- `pnpm test`: 47 passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a floating clipboard control to the successful raw-content view.
- Copies the complete decrypted content using the Clipboard API.
- Displays a two-second visual success state and clears its timer when the component is destroyed.
- The success feedback is not currently announced to assistive technology.
</details>

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking accessibility issue in the copy confirmation.

Clipboard copying and timer cleanup are implemented coherently, but the static accessible name prevents screen-reader users from receiving the new success feedback.

**Files Needing Attention:** src/routes/r/[id]/+page.svelte

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/r/[id]/+page.svelte | Adds the copy interaction, icons, timer cleanup, and fixed-position styling; the visual Copied state lacks an accessible status update. |

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Froutes%2Fr%2F%5Bid%5D%2F%2Bpage.svelte%3A83%0A**Expose%20the%20copied%20status**%0A%0AAfter%20a%20successful%20copy%2C%20the%20visible%20label%20changes%20to%20%E2%80%9CCopied%E2%80%9D%20while%20the%20overriding%20%60aria-label%60%20remains%20%E2%80%9CCopy%20raw%20content%2C%E2%80%9D%20so%20screen-reader%20users%20receive%20no%20confirmation%20and%20may%20repeat%20the%20action.%0A%0A%60%60%60suggestion%0A%09%3Cbutton%0A%09%09type%3D%22button%22%0A%09%09onclick%3D%7BcopyContent%7D%0A%09%09class%3D%22copy-button%22%0A%09%09aria-label%3D%7Bcopied%20%3F%20'Copied%20raw%20content'%20%3A%20'Copy%20raw%20content'%7D%0A%09%3E%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=206&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22feat%2Fraw-view-copy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fraw-view-copy%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Froutes%2Fr%2F%5Bid%5D%2F%2Bpage.svelte%3A83%0A**Expose%20the%20copied%20status**%0A%0AAfter%20a%20successful%20copy%2C%20the%20visible%20label%20changes%20to%20%E2%80%9CCopied%E2%80%9D%20while%20the%20overriding%20%60aria-label%60%20remains%20%E2%80%9CCopy%20raw%20content%2C%E2%80%9D%20so%20screen-reader%20users%20receive%20no%20confirmation%20and%20may%20repeat%20the%20action.%0A%0A%60%60%60suggestion%0A%09%3Cbutton%0A%09%09type%3D%22button%22%0A%09%09onclick%3D%7BcopyContent%7D%0A%09%09class%3D%22copy-button%22%0A%09%09aria-label%3D%7Bcopied%20%3F%20'Copied%20raw%20content'%20%3A%20'Copy%20raw%20content'%7D%0A%09%3E%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=206&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Froutes%2Fr%2F%5Bid%5D%2F%2Bpage.svelte%3A83%0A**Expose%20the%20copied%20status**%0A%0AAfter%20a%20successful%20copy%2C%20the%20visible%20label%20changes%20to%20%E2%80%9CCopied%E2%80%9D%20while%20the%20overriding%20%60aria-label%60%20remains%20%E2%80%9CCopy%20raw%20content%2C%E2%80%9D%20so%20screen-reader%20users%20receive%20no%20confirmation%20and%20may%20repeat%20the%20action.%0A%0A%60%60%60suggestion%0A%09%3Cbutton%0A%09%09type%3D%22button%22%0A%09%09onclick%3D%7BcopyContent%7D%0A%09%09class%3D%22copy-button%22%0A%09%09aria-label%3D%7Bcopied%20%3F%20'Copied%20raw%20content'%20%3A%20'Copy%20raw%20content'%7D%0A%09%3E%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=206&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/routes/r/[id]/+page.svelte:83
**Expose the copied status**

After a successful copy, the visible label changes to “Copied” while the overriding `aria-label` remains “Copy raw content,” so screen-reader users receive no confirmation and may repeat the action.

```suggestion
	<button
		type="button"
		onclick={copyContent}
		class="copy-button"
		aria-label={copied ? 'Copied raw content' : 'Copy raw content'}
	>
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add copy button to raw view"](https://github.com/ishannaik/cloakbin/commit/7c505a955670d6aba8221357dd9901aa0ccecce1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51475556)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->