### PR TITLE
feat: prefill editor from query params

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -162,6 +162,21 @@
 			selectedTheme = savedTheme;
 		}
 
+		// Safe deep-link prefill; invalid or unknown params are ignored.
+		const params = new URLSearchParams(window.location.search);
+		const lang = params.get('lang');
+		if (lang && (languages.some((option) => option.value === lang) || lang === 'auto' || lang === 'plaintext')) {
+			selectedLanguage = lang;
+		}
+		if (params.get('burn') === '1') {
+			burnAfterRead = true;
+		}
+		const expiryParam = params.get('expiry');
+		const expiryValue = expiryOptions.find((option) => option.value === expiryParam)?.value;
+		if (expiryValue) {
+			expiry = expiryValue;
+		}
+
 		// Restore draft from localStorage
 		const draft = localStorage.getItem('cloakbin_draft');
 		if (draft && !content) {


### PR DESCRIPTION
Closes #170.

## Summary
Supports safe query params on the home page so links can preselect language, burn-after-read, and expiry without allowing arbitrary input.

## Changes
- `?lang=python` preselects the language when it matches an allowed picker value, `auto`, or `plaintext`.
- `?burn=1` enables burn-after-read.
- `?expiry=24h` preselects expiry when it matches an existing option.
- Invalid or unknown params are ignored silently.
- Draft-restore behavior remains unchanged.

## Verification
- `pnpm check`: 0 errors (8 pre-existing warnings).
- `pnpm test`: 47 passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds allowlisted query-parameter prefilling for the home-page editor while preserving existing defaults and draft restoration.
- Valid `lang` values preselect the language picker.
- `burn=1` enables burn-after-read.
- Valid `expiry` values preselect an existing expiry option.
- Unknown or invalid values are ignored.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with query parameters constrained to existing editor options and no blocking failure identified.

The new initialization accepts only explicit boolean and allowlisted picker values, while invalid inputs retain existing defaults and downstream submission behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/+page.svelte | Adds bounded query-parameter parsing during mount; accepted values align with the existing picker and submission contracts, with no actionable changed-code defect identified. |

<sub>Reviews (1): Last reviewed commit: ["feat: prefill editor from query params"](https://github.com/ishannaik/cloakbin/commit/c8954b6c94fa2572dfde47a99237275ee22cf6df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51475857)</sub>

<!-- /greptile_comment -->