### PR TITLE
feat: add word wrap toggle to paste viewer

### DIFF
--- a/src/routes/p/[id]/+page.svelte
+++ b/src/routes/p/[id]/+page.svelte
@@ -44,6 +44,14 @@
 	let pasteData = $state<{ content: string; hasPassword: boolean; salt?: string; burnAfterRead: boolean; createdAt: string; expiresAt: string; language?: string } | null>(null);
 	let detectedLanguage = $state('javascript');
 	let languageExtension = $state<LanguageSupport>(javascript());
+	let wrapLines = $state(typeof localStorage !== 'undefined' ? localStorage.getItem('cloakbin_wrap') !== '0' : true);
+
+	function toggleWrap() {
+		wrapLines = !wrapLines;
+		if (typeof localStorage !== 'undefined') {
+			localStorage.setItem('cloakbin_wrap', wrapLines ? '1' : '0');
+		}
+	}
 
 	// Theme state
 	let selectedTheme = $state('oneDark');
@@ -545,6 +553,15 @@
 					{/if}
 				</button>
 				<button
+					type="button"
+					onclick={toggleWrap}
+					aria-pressed={wrapLines}
+					aria-label={wrapLines ? 'Disable line wrapping' : 'Enable line wrapping'}
+					class="h-9 sm:h-10 p-2 sm:px-3 bg-zinc-700 hover:bg-zinc-600 text-zinc-100 rounded font-medium transition-all duration-150 active:scale-95 flex items-center gap-2"
+				>
+					<span class="hidden sm:inline">{wrapLines ? 'Wrap' : 'No wrap'}</span>
+				</button>
+				<button
 					onclick={duplicatePaste}
 					title="{mod}+D"
 					class="h-9 sm:h-10 p-2 sm:px-3 bg-zinc-700 hover:bg-zinc-600 text-zinc-100 rounded font-medium transition-all duration-150 active:scale-95 flex items-center gap-2"
@@ -721,7 +738,7 @@
 				value={content}
 				lang={languageExtension}
 				theme={currentTheme}
-				extensions={[EditorView.lineWrapping, EditorView.editable.of(false)]}
+				extensions={[EditorView.editable.of(false), ...(wrapLines ? [EditorView.lineWrapping] : [])]}
 				styles={{
 					'&': {
 						height: '100%',


### PR DESCRIPTION
Closes #163.

## Summary
Adds a Wrap / No wrap toggle to the paste viewer so wide tables and long log lines can use horizontal scrolling instead of forced wrapping.

## Changes
- Adds a `wrapLines` state defaulting to true.
- Toggles `EditorView.lineWrapping` in the viewer extensions.
- Persists the choice in `localStorage` under `cloakbin_wrap`.
- Exposes `aria-pressed` and a dynamic `aria-label` on the toggle.

## Verification
- `pnpm check`: 0 errors (8 pre-existing warnings).
- `pnpm test`: 47 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a line-wrapping toggle to the paste viewer.
  * The selected wrapping preference is saved and restored for future visits.
  * Preserved read-only viewing while applying the selected display mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a persisted line-wrapping preference to the paste viewer.
- Adds a Wrap / No wrap control with accessible pressed state and labels.
- Reconfigures CodeMirror to include line wrapping only when enabled.
- Stores the preference in `localStorage` under `cloakbin_wrap`.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/p/[id]/+page.svelte | Adds the persisted wrapping state, accessible toggle, and conditional CodeMirror line-wrapping extension without an eligible follow-up defect. |

<sub>Reviews (2): Last reviewed commit: ["merge main: keep wrap toggle and select ..."](https://github.com/ishannaik/cloakbin/commit/b7e04e3c71d462d4209bbaa9c97345763c6ec7cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51477529)</sub>

<!-- /greptile_comment -->