### PR TITLE
feat: add live expiry countdown

### DIFF
--- a/src/routes/p/[id]/+page.svelte
+++ b/src/routes/p/[id]/+page.svelte
@@ -121,8 +121,7 @@
 	}
 
 	// Format relative time
-	function formatRelativeTime(date: Date): string {
-		const now = new Date();
+	function formatRelativeTime(date: Date, now: Date): string {
 		const diffMs = date.getTime() - now.getTime();
 		const diffMins = Math.floor(diffMs / 60000);
 		const diffHours = Math.floor(diffMins / 60);
@@ -150,7 +149,9 @@
 
 	// Derived values for display
 	let createdTimeAgo = $derived(createdAt ? formatTimeAgo(createdAt) : '');
-	let expiresIn = $derived(expiresAt ? formatRelativeTime(expiresAt) : '');
+	let now = $state(new Date());
+	let expiresIn = $derived(expiresAt ? formatRelativeTime(expiresAt, now) : '');
+	let expiryTimer: ReturnType<typeof setInterval>;
 
 	// Copy content to clipboard
 	async function copyToClipboard() {
@@ -447,6 +448,10 @@
 	// Handle bfcache (back-forward cache) security
 	// Without this, pressing back then forward shows decrypted content from memory
 	onMount(() => {
+		expiryTimer = setInterval(() => {
+			now = new Date();
+		}, 30_000);
+
 		// Restore theme from localStorage
 		const savedTheme = localStorage.getItem('cloakbin_theme');
 		if (savedTheme && savedTheme in themes) {
@@ -487,6 +492,7 @@
 		loadAndDecrypt();
 
 		return () => {
+			clearInterval(expiryTimer);
 			window.removeEventListener('pagehide', handlePageHide);
 			window.removeEventListener('pageshow', handlePageShow);
 			window.removeEventListener('hashchange', handleHashChange);


### PR DESCRIPTION
Closes #168.

## Summary
Turns the static Expires in label into a live countdown that recomputes every 30 seconds and shows Expired at zero.

## Changes
- Adds a reactive `now` state.
- Passes `now` into `formatRelativeTime` so the derived label recomputes.
- Starts a 30-second interval in `onMount` and clears it in the cleanup.
- Pastes with no `expiresAt` still render an empty label.

## Verification
- `pnpm check`: 0 errors (8 pre-existing warnings).
- `pnpm test`: 47 passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR converts the static paste-expiry label into a reactive countdown.
- Adds reactive current-time state and passes it to the relative-time formatter.
- Refreshes the current time every 30 seconds.
- Clears the interval when the component is destroyed.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the countdown interval correctly tied to the component lifecycle.

The reactive timestamp updates the expiry label at the intended cadence, and the newly created interval is cleared during component cleanup without introducing a concrete blocking failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/p/[id]/+page.svelte | Adds a lifecycle-managed timer that updates the derived expiry label while preserving empty labels for pastes without an expiry. |

<sub>Reviews (1): Last reviewed commit: ["feat: add live expiry countdown"](https://github.com/ishannaik/cloakbin/commit/fb2fc0027fdb95710e2f388550add2f318e8f51c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51477713)</sub>

<!-- /greptile_comment -->