### PR TITLE
feat: add password strength meter

### DIFF
--- a/src/lib/components/PasswordStrength.svelte
+++ b/src/lib/components/PasswordStrength.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	let { score = 0 }: { score?: number } = $props();
+
+	const label = $derived(score >= 3 ? 'Strong' : score >= 2 ? 'Fair' : 'Weak');
+	const fill = $derived(score >= 3 ? 'bg-teal-500' : score >= 2 ? 'bg-amber-400' : 'bg-red-400');
+</script>
+
+<div class="mt-1 flex items-center gap-2" aria-label="Password strength: {label}">
+	<div class="flex gap-1" aria-hidden="true">
+		{#each [1, 2, 3] as level}
+			<span class="h-1.5 w-8 rounded-full {level <= score ? fill : 'bg-zinc-700'}"></span>
+		{/each}
+	</div>
+	<span class="text-xs text-zinc-400">{label}</span>
+</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -145,9 +145,13 @@
 		let score = 0;
 		if (value.length >= 8) score++;
 		if (value.length >= 12) score++;
-		if (/[a-z]/.test(value) && /[A-Z]/.test(value)) score++;
-		if (/\d/.test(value)) score++;
-		if (/[^A-Za-z0-9]/.test(value)) score++;
+		// Class diversity only counts once the password has a length floor;
+		// otherwise a 4-char "aA1!" would score Strong and mislead the user.
+		if (value.length >= 8) {
+			if (/[a-z]/.test(value) && /[A-Z]/.test(value)) score++;
+			if (/\d/.test(value)) score++;
+			if (/[^A-Za-z0-9]/.test(value)) score++;
+		}
 		return Math.min(3, score);
 	}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import logo from '$lib/assets/logo.svg';
 	import LazyCodeMirror from '$lib/components/LazyCodeMirror.svelte';
+	import PasswordStrength from '$lib/components/PasswordStrength.svelte';
 	import ExpirySelect from '$lib/components/ExpirySelect.svelte';
 	import EncryptionOverlay from '$lib/components/EncryptionOverlay.svelte';
 	import ImportModal from '$lib/components/ImportModal.svelte';
@@ -137,6 +138,18 @@
 	let password = $state('');
 	let burnAfterRead = $state(false);
 	let selectedLanguage = $state('auto'); // 'auto' means auto-detect language using highlight.js
+	let passwordScore = $derived(scorePassword(password));
+
+	function scorePassword(value: string): number {
+		if (!value) return 0;
+		let score = 0;
+		if (value.length >= 8) score++;
+		if (value.length >= 12) score++;
+		if (/[a-z]/.test(value) && /[A-Z]/.test(value)) score++;
+		if (/\d/.test(value)) score++;
+		if (/[^A-Za-z0-9]/.test(value)) score++;
+		return Math.min(3, score);
+	}
 
 	// Available languages for manual selection (shared allowlist)
 	const languages = LANGUAGE_PICKER_OPTIONS;
@@ -657,13 +670,18 @@
 			<span class="text-zinc-400 text-sm hidden sm:inline">Password</span>
 		</label>
 		{#if usePassword}
-			<input
-				type="password"
-				bind:value={password}
-				placeholder="Password..."
-				maxlength={128}
-				class="bg-bg-secondary border border-zinc-700 rounded px-2 py-2 text-sm w-24 sm:w-32 focus:outline-none focus:border-teal-500"
-			/>
+			<div class="flex flex-col items-start gap-1">
+				<input
+					type="password"
+					bind:value={password}
+					placeholder="Password..."
+					maxlength={128}
+					class="bg-bg-secondary border border-zinc-700 rounded px-2 py-2 text-sm w-24 sm:w-32 focus:outline-none focus:border-teal-500"
+				/>
+				{#if password}
+					<PasswordStrength score={passwordScore} />
+				{/if}
+			</div>
 		{/if}
 		<!-- Burn toggle -->
 		<label class="relative flex items-center gap-1.5 cursor-pointer group">


### PR DESCRIPTION
Closes #167.

## Summary
Adds a password-strength meter under the create-page password field so users can spot a weak password before PBKDF2 derives the paste key.

## Changes
- Adds a small `PasswordStrength` component with a segmented bar and Weak / Fair / Strong label.
- Scores the password from length and character classes, clamped to 3 segments.
- Shows the meter only when the password toggle is on and the field is non-empty.
- Keeps the Create button disabled logic untouched.

## Verification
- `pnpm check`: 0 errors (8 pre-existing warnings).
- `pnpm test`: 47 passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a password-strength indicator to the create-page password field.
- Scores passwords using length and character diversity, with diversity gated behind an eight-character minimum.
- Displays a segmented Weak, Fair, or Strong meter for non-empty passwords.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/+page.svelte | Adds password scoring and conditionally renders the strength meter; the previously reported minimum-length bypass is fixed. |
| src/lib/components/PasswordStrength.svelte | Adds a presentational three-segment strength bar with Weak, Fair, and Strong labels. |

<sub>Reviews (3): Last reviewed commit: ["merge main: keep password toggle and str..."](https://github.com/ishannaik/cloakbin/commit/ac21c2aafcfb3a9ee63e4ae70725031809592d03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51478362)</sub>

<!-- /greptile_comment -->