### PR TITLE
test: cover cipher morph animation utility

### DIFF
--- a/src/lib/utils/cipher-morph.test.ts
+++ b/src/lib/utils/cipher-morph.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { startCipherMorph } from './cipher-morph';
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+function stubReducedMotion(reduced: boolean) {
+	vi.stubGlobal('window', {
+		matchMedia: () => ({ matches: reduced }),
+	});
+}
+
+function stubRaf() {
+	const ids = new Set<number>();
+	let cancelled = false;
+	let pending: FrameRequestCallback | null = null;
+
+	vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+		pending = callback;
+		const id = ids.size + 1;
+		ids.add(id);
+		return id;
+	});
+	vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+		if (ids.has(id)) cancelled = true;
+	});
+
+	return {
+		runNow(now: number) {
+			const callback = pending;
+			pending = null;
+			callback?.(now);
+		},
+		get cancelled() {
+			return cancelled;
+		},
+	};
+}
+
+describe('startCipherMorph', () => {
+	it('calls onFrame once with the target when reduced motion is on', () => {
+		stubReducedMotion(true);
+		const onFrame = vi.fn();
+
+		startCipherMorph('abc', 'xyz', onFrame);
+
+		expect(onFrame).toHaveBeenCalledTimes(1);
+		expect(onFrame).toHaveBeenCalledWith('xyz');
+	});
+
+	it('handles empty source and target without scheduling frames', () => {
+		stubReducedMotion(true);
+		const onFrame = vi.fn();
+
+		startCipherMorph('', '', onFrame);
+
+		expect(onFrame).toHaveBeenCalledTimes(1);
+		expect(onFrame).toHaveBeenCalledWith('');
+	});
+
+	it('cleanup cancels the scheduled frame', () => {
+		stubReducedMotion(false);
+		const raf = stubRaf();
+		const onFrame = vi.fn();
+
+		const cleanup = startCipherMorph('abc', 'xyz', onFrame);
+		cleanup();
+
+		expect(raf.cancelled).toBe(true);
+	});
+
+	it('pads a shorter source and completes to the target', () => {
+		stubReducedMotion(false);
+		const raf = stubRaf();
+		const onFrame = vi.fn();
+
+		startCipherMorph('a', 'xyz', onFrame);
+		raf.runNow(performance.now() + 3000);
+
+		expect(onFrame).toHaveBeenLastCalledWith('xyz');
+	});
+});


### PR DESCRIPTION
Closes #145.

## Summary
Adds Vitest coverage for `startCipherMorph` without needing a browser, using stubbed `window.matchMedia` and RAF.

## Changes
- Covers reduced-motion fast path (single immediate frame with the target).
- Covers empty source and target.
- Covers cleanup cancelling the scheduled frame.
- Covers shorter source padded and completing to the target.

## Verification
- `pnpm test`: 51 passed across 6 files.
- `pnpm check`: 0 errors (8 pre-existing warnings).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds focused Vitest coverage for the cipher morph animation utility.
- Covers reduced-motion and empty-input fast paths.
- Verifies scheduled-frame cleanup.
- Verifies completion when the source is shorter than the target.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The change only adds focused tests, and the new stubs, cleanup, and assertions align with the utility’s current control flow without altering production behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/utils/cipher-morph.test.ts | Adds isolated Node-compatible tests with stubbed browser APIs; no actionable defects were identified. |

<sub>Reviews (1): Last reviewed commit: ["test: cover cipher morph animation utili..."](https://github.com/ishannaik/cloakbin/commit/03b04424afd840e041cc3d7097920d149fda066d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51478925)</sub>

<!-- /greptile_comment -->