### PR TITLE
fix: only apply imported language when picker supports it

### DIFF
--- a/src/lib/languages.test.ts
+++ b/src/lib/languages.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
 	detectLanguageFromFilename,
+	isPickerLanguage,
 	normalizePasteLanguage,
 	isAllowedPasteLanguage,
 	PASTE_LANGUAGE_SET,
@@ -55,6 +56,20 @@ describe('LANGUAGE_PICKER_OPTIONS', () => {
 			if (opt.value === 'auto') continue;
 			expect(PASTE_LANGUAGE_SET.has(opt.value)).toBe(true);
 		}
+	});
+});
+
+describe('isPickerLanguage', () => {
+	it('returns true for options in the create-page picker', () => {
+		expect(isPickerLanguage('javascript')).toBe(true);
+		expect(isPickerLanguage('auto')).toBe(true);
+		expect(isPickerLanguage('plaintext')).toBe(true);
+	});
+
+	it('returns false for valid paste languages without a picker option', () => {
+		expect(isPickerLanguage('dockerfile')).toBe(false);
+		expect(isPickerLanguage('graphql')).toBe(false);
+		expect(isPickerLanguage('makefile')).toBe(false);
 	});
 });
 

--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -102,6 +102,11 @@ export const LANGUAGE_PICKER_OPTIONS: ReadonlyArray<{ value: string; label: stri
 	{ value: 'plaintext', label: 'Plain Text' }
 ];
 
+/** True when a language id is offered by the create-page picker (or auto). */
+export function isPickerLanguage(language: string): boolean {
+	return LANGUAGE_PICKER_OPTIONS.some((option) => option.value === language);
+}
+
 /**
  * Normalize a client-supplied language string for storage.
  * Unknown / non-string values become `plaintext` (never stored raw).

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,7 +12,8 @@
 	import {
 		detectLanguageFromFilename,
 		LANGUAGE_PICKER_OPTIONS,
-		isAllowedPasteLanguage
+		isAllowedPasteLanguage,
+		isPickerLanguage
 	} from '$lib/languages';
 	import {
 		dracula,
@@ -758,6 +759,6 @@
 	onImport={(text, filename) => {
 		content = text;
 		const language = detectLanguageFromFilename(filename);
-		if (language) selectedLanguage = language;
+		if (language && isPickerLanguage(language)) selectedLanguage = language;
 	}}
 />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -759,6 +759,6 @@
 	onImport={(text, filename) => {
 		content = text;
 		const language = detectLanguageFromFilename(filename);
-		if (language && isPickerLanguage(language)) selectedLanguage = language;
+		selectedLanguage = language && isPickerLanguage(language) ? language : 'auto';
 	}}
 />


### PR DESCRIPTION
Closes #199.

## Summary
Prevents imports from setting a `selectedLanguage` that the create-page picker cannot display. The paste remains valid because all detected ids are still allowed for storage.

## Changes
- Adds `isPickerLanguage` to `src/lib/languages.ts`.
- Uses it in the home page import handler.
- Adds tests for picker-supported and picker-missing languages.

## Verification
- `pnpm test`: 49 passed.
- `pnpm check`: 0 errors (8 pre-existing warnings).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR prevents file imports from selecting language identifiers unavailable in the create-page picker.
- Adds `isPickerLanguage` based on the picker’s configured options.
- Resets imported files to automatic detection when their detected language is not picker-supported.
- Adds coverage for picker-supported and picker-missing language identifiers.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/languages.ts | Adds a picker-membership helper derived directly from `LANGUAGE_PICKER_OPTIONS`. |
| src/routes/+page.svelte | Applies detected languages only when picker-supported and otherwise resets the selection to `auto`, resolving the previously reported stale-language behavior. |
| src/lib/languages.test.ts | Covers accepted picker options and valid paste languages intentionally omitted from the picker. |

<sub>Reviews (2): Last reviewed commit: ["fix: reset language to auto on unsupport..."](https://github.com/ishannaik/cloakbin/commit/d43d639b5870bf6fb3bca17ae2d8daf5a172b8e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51479161)</sub>

<!-- /greptile_comment -->