### PR TITLE
feat: show line and character counts in paste info bar

### DIFF
--- a/src/routes/p/[id]/+page.svelte
+++ b/src/routes/p/[id]/+page.svelte
@@ -151,6 +151,8 @@
 	// Derived values for display
 	let createdTimeAgo = $derived(createdAt ? formatTimeAgo(createdAt) : '');
 	let expiresIn = $derived(expiresAt ? formatRelativeTime(expiresAt) : '');
+	let lineCount = $derived(content.length > 0 ? content.split(/\r?\n/).length : 0);
+	let charCount = $derived(content.length);
 
 	// Copy content to clipboard
 	async function copyToClipboard() {
@@ -739,6 +741,8 @@
 			<span class="px-2 py-0.5 bg-zinc-700 text-zinc-300 rounded text-xs font-mono">{detectedLanguage}</span>
 			<span>·</span>
 			<span>Created {createdTimeAgo}</span>
+			<span>·</span>
+			<span>{lineCount} lines · {charCount} chars</span>
 			<span>·</span>
 			<span>Expires in {expiresIn}</span>
 		</div>

--- a/src/routes/p/[id]/+page.svelte
+++ b/src/routes/p/[id]/+page.svelte
@@ -737,7 +737,7 @@
 		</div>
 
 		<!-- Info Bar -->
-		<div class="flex items-center justify-center gap-4 py-4 border-t border-zinc-800 text-sm text-zinc-500">
+		<div class="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 py-4 border-t border-zinc-800 text-sm text-zinc-500">
 			<span class="px-2 py-0.5 bg-zinc-700 text-zinc-300 rounded text-xs font-mono">{detectedLanguage}</span>
 			<span>·</span>
 			<span>Created {createdTimeAgo}</span>


### PR DESCRIPTION
Closes #164.

## Summary
Adds line and character counts to the paste-view info bar, computed reactively from the decrypted content.

## Changes
- Adds `$derived` line and char counts.
- Shows `N lines · M chars` between Created and Expires in the success-state info bar.
- Handles empty content with 0 lines / 0 chars.

## Verification
- `pnpm check`: 0 errors (8 pre-existing warnings).
- `pnpm test`: 47 passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds reactive line and character counts to the decrypted paste view.
- Displays the counts between creation and expiration metadata.
- Allows the metadata row to wrap on narrow viewports, resolving the previously reported clipping.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/p/[id]/+page.svelte | Adds reactive content counts and updates the info bar to wrap responsively; the previously reported mobile clipping issue is fixed. |

<sub>Reviews (2): Last reviewed commit: ["merge main: keep countdown and line/char..."](https://github.com/ishannaik/cloakbin/commit/84e3a60230a509d3ec337ba89304ddfa85a8fb31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51479348)</sub>

<!-- /greptile_comment -->