### PR TITLE
feat: add tidy button to trim editor whitespace

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -301,6 +301,12 @@
 		}, 600);
 	}
 
+	function tidyContent() {
+		const lines = content.split(/\r?\n/).map((line) => line.replace(/[ \t]+$/g, ''));
+		while (lines.length > 1 && lines[lines.length - 1] === '') lines.pop();
+		content = lines.join('\n');
+	}
+
 
 	const themes = {
 		oneDark: { name: 'One Dark', theme: oneDark },
@@ -531,6 +537,14 @@
 					style="transform: rotate({$newButtonRotation}deg)"
 				>+</span>
 				<span class="hidden sm:inline">{newButtonSuccess ? 'Cleared!' : 'New'}</span>
+			</button>
+			<button
+				type="button"
+				onclick={tidyContent}
+				title="Trim trailing whitespace"
+				class="p-2 sm:p-2.5 bg-zinc-700 hover:bg-zinc-600 text-zinc-100 rounded font-medium transition-all duration-150 active:scale-95"
+			>
+				Tidy
 			</button>
 			<!-- Import -->
 			<button

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -302,9 +302,12 @@
 	}
 
 	function tidyContent() {
-		const lines = content.split(/\r?\n/).map((line) => line.replace(/[ \t]+$/g, ''));
+		// Preserve the dominant line ending; splitting on both forms and
+		// joining with a single one would silently convert CRLF docs to LF.
+		const hasCrlf = content.includes('\r\n');
+		const lines = content.split(/\r?\n/).map((line) => line.replace(/[ 	]+$/g, ''));
 		while (lines.length > 1 && lines[lines.length - 1] === '') lines.pop();
-		content = lines.join('\n');
+		content = lines.join(hasCrlf ? '\r\n' : '\n');
 	}
 
 


### PR DESCRIPTION
Closes #173.

## Summary
Adds a Tidy button to the home editor header that trims trailing whitespace per line and collapses trailing blank lines, all client-side.

## Changes
- Adds `tidyContent()` using pure string handling.
- Adds a Tidy button beside New / Import with the existing muted button style.
- The autosave draft flow continues to persist the updated content.

## Verification
- `pnpm check`: 0 errors (8 pre-existing warnings).
- `pnpm test`: 47 passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a client-side Tidy action that removes trailing horizontal whitespace and trailing blank lines. Its line-ending fix preserves uniform CRLF documents but still normalizes mixed-line-ending documents.
- Adds `tidyContent()` and a Tidy button to the editor header.
- Reuses the existing reactive content flow so tidied text continues through autosave.
- Chooses one output newline sequence for the entire document.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because Tidy still changes unrelated line endings in mixed-line-ending documents.

The updated implementation preserves uniform CRLF input, but the presence of one CRLF separator makes it rewrite every LF separator as CRLF.

**Files Needing Attention:** src/routes/+page.svelte

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/+page.svelte | Adds the Tidy transformation and button, but mixed LF/CRLF documents are still normalized to CRLF. |

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Froutes%2F%2Bpage.svelte%3A307-310%0A**Mixed%20line%20endings%20are%20normalized**%0A%0AWhen%20a%20document%20contains%20both%20CRLF%20and%20LF%20separators%2C%20%60content.includes%28'%5Cr%5Cn'%29%60%20selects%20CRLF%20for%20every%20line%20during%20reassembly%2C%20causing%20Tidy%20to%20alter%20LF%20separators%20in%20addition%20to%20removing%20trailing%20whitespace.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=216&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22feat%2Ftidy-button%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ftidy-button%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Froutes%2F%2Bpage.svelte%3A307-310%0A**Mixed%20line%20endings%20are%20normalized**%0A%0AWhen%20a%20document%20contains%20both%20CRLF%20and%20LF%20separators%2C%20%60content.includes%28'%5Cr%5Cn'%29%60%20selects%20CRLF%20for%20every%20line%20during%20reassembly%2C%20causing%20Tidy%20to%20alter%20LF%20separators%20in%20addition%20to%20removing%20trailing%20whitespace.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=216&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Froutes%2F%2Bpage.svelte%3A307-310%0A**Mixed%20line%20endings%20are%20normalized**%0A%0AWhen%20a%20document%20contains%20both%20CRLF%20and%20LF%20separators%2C%20%60content.includes%28'%5Cr%5Cn'%29%60%20selects%20CRLF%20for%20every%20line%20during%20reassembly%2C%20causing%20Tidy%20to%20alter%20LF%20separators%20in%20addition%20to%20removing%20trailing%20whitespace.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=216&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/routes/+page.svelte:307-310
**Mixed line endings are normalized**

When a document contains both CRLF and LF separators, `content.includes('\r\n')` selects CRLF for every line during reassembly, causing Tidy to alter LF separators in addition to removing trailing whitespace.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: preserve line endings in tidy"](https://github.com/ishannaik/cloakbin/commit/5c2e97dc33916b2cd40ece73c70735777b80fdc2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51479472)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->