### PR TITLE
fix: apply read rate limit to burn endpoint

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -159,7 +159,10 @@ export const handle: Handle = async ({ event, resolve }) => {
 		if (method === 'POST' && path === '/api/paste') {
 			limit = RATE_LIMITS.createPaste;
 			limitType = 'createPaste';
-		} else if (method === 'GET' && path.startsWith('/api/paste/')) {
+		} else if (
+			path.startsWith('/api/paste/') &&
+			(method === 'GET' || (method === 'POST' && path.endsWith('/burn')))
+		) {
 			limit = RATE_LIMITS.readPaste;
 			limitType = 'readPaste';
 		}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -6,6 +6,7 @@
 import type { Handle } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { verifyAdminSession } from '$lib/server/admin-auth';
+import { RATE_LIMITS, resolveRateLimitType } from '$lib/server/rateLimit';
 
 // ============================================
 // RATE LIMITING (In-Memory)
@@ -46,13 +47,6 @@ interface RateLimitEntry {
 
 // Store: IP -> { count, resetTime }
 const rateLimitStore = new Map<string, RateLimitEntry>();
-
-// Rate limit configurations
-const RATE_LIMITS = {
-	createPaste: { requests: 10, windowMs: 60 * 1000 }, // 10 pastes per minute
-	readPaste: { requests: 60, windowMs: 60 * 1000 }, // 60 reads per minute
-	default: { requests: 100, windowMs: 60 * 1000 } // 100 requests per minute
-} as const;
 
 // Cleanup old entries every 5 minutes to prevent memory bloat
 const CLEANUP_INTERVAL = 5 * 60 * 1000;
@@ -153,19 +147,8 @@ export const handle: Handle = async ({ event, resolve }) => {
 		const method = event.request.method;
 
 		// Determine which rate limit to apply
-		let limit: (typeof RATE_LIMITS)[keyof typeof RATE_LIMITS] = RATE_LIMITS.default;
-		let limitType = 'default';
-
-		if (method === 'POST' && path === '/api/paste') {
-			limit = RATE_LIMITS.createPaste;
-			limitType = 'createPaste';
-		} else if (
-			path.startsWith('/api/paste/') &&
-			(method === 'GET' || (method === 'POST' && path.endsWith('/burn')))
-		) {
-			limit = RATE_LIMITS.readPaste;
-			limitType = 'readPaste';
-		}
+		const limitType = resolveRateLimitType(method, path);
+		const limit = RATE_LIMITS[limitType];
 
 		// Check rate limit
 		const { limited, resetIn } = isRateLimited(`${ip}:${limitType}`, limit);

--- a/src/lib/server/rateLimit.test.ts
+++ b/src/lib/server/rateLimit.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRateLimitType } from './rateLimit';
+
+describe('resolveRateLimitType', () => {
+	it('routes paste creation to its own bucket', () => {
+		expect(resolveRateLimitType('POST', '/api/paste')).toBe('createPaste');
+	});
+
+	it('routes paste reads to the read bucket', () => {
+		expect(resolveRateLimitType('GET', '/api/paste/abc')).toBe('readPaste');
+	});
+
+	it('routes burn requests to the read bucket', () => {
+		expect(resolveRateLimitType('POST', '/api/paste/abc/burn')).toBe('readPaste');
+	});
+
+	it('keeps unrelated POST paths on the default bucket', () => {
+		expect(resolveRateLimitType('POST', '/api/paste/abc')).toBe('default');
+		expect(resolveRateLimitType('POST', '/api/other')).toBe('default');
+	});
+
+	it('keeps non-paste paths on the default bucket', () => {
+		expect(resolveRateLimitType('GET', '/api/health')).toBe('default');
+	});
+});

--- a/src/lib/server/rateLimit.ts
+++ b/src/lib/server/rateLimit.ts
@@ -1,0 +1,13 @@
+export const RATE_LIMITS = {
+	createPaste: { requests: 10, windowMs: 60 * 1000 }, // 10 pastes per minute
+	readPaste: { requests: 60, windowMs: 60 * 1000 }, // 60 reads per minute
+	default: { requests: 100, windowMs: 60 * 1000 } // 100 requests per minute
+} as const;
+
+export function resolveRateLimitType(method: string, path: string): keyof typeof RATE_LIMITS {
+	if (method === 'POST' && path === '/api/paste') return 'createPaste';
+	if (path.startsWith('/api/paste/') && (method === 'GET' || (method === 'POST' && path.endsWith('/burn')))) {
+		return 'readPaste';
+	}
+	return 'default';
+}


### PR DESCRIPTION
Closes #183.

## Summary
Routes `POST /api/paste/[id]/burn` to the existing `readPaste` bucket (60/min) instead of the looser default, while leaving `POST /api/paste` on `createPaste`.

## Why this bucket
Burning is destructive and unauthenticated, and it follows the same paste-access path as reads. Reusing `readPaste` avoids adding a new bucket while still tightening the destructive path.

## Verification
- `pnpm check`: 0 errors (8 pre-existing warnings).
- `pnpm test`: 47 passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR extracts rate-limit configuration and route classification into a testable server module, then assigns burn requests to the existing read bucket.
- Routes paste creation to `createPaste`.
- Routes paste reads and burns to `readPaste`.
- Adds focused route-classification tests.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/hooks.server.ts | Replaces inline route classification with the shared resolver and uses its result for limit selection and counter keys. |
| src/lib/server/rateLimit.ts | Defines shared rate-limit settings and classifies burn requests under the read bucket. |
| src/lib/server/rateLimit.test.ts | Covers classification of creation, reads, burns, and unrelated routes. |

<sub>Reviews (2): Last reviewed commit: ["test: cover rate limit bucket routing"](https://github.com/ishannaik/cloakbin/commit/8c3c3552265b86b3e03d6e2add938b7b3b5048ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51479664)</sub>

<!-- /greptile_comment -->