### PR TITLE
feat: add adapter proposal issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/adapter_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/adapter_proposal.yml
@@ -1,0 +1,41 @@
+name: Adapter proposal
+description: Propose a new storage adapter for self-hosters
+title: "[adapter]: "
+labels: ["enhancement", "adapter"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        New adapters let self-hosters choose where paste data lives. Please
+        describe the backend, why it helps, and how it could be implemented.
+  - type: input
+    id: backend
+    attributes:
+      label: Storage backend
+      description: Database, object store, or other backend to support.
+      placeholder: e.g. Turso / libsql-client
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this useful for self-hosters?
+      description: Deployment constraints, operational benefits, or migration needs.
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Implementation notes
+      description: Adapter interface, schema, auth, deployment, or migration details.
+      render: text
+  - type: dropdown
+    id: willing
+    attributes:
+      label: Are you willing to implement it?
+      options:
+        - Yes
+        - No
+        - I can help review or test
+    validations:
+      required: true


### PR DESCRIPTION
Closes #146.

## Summary
Adds the missing `adapter_proposal.yml` issue template so the New Issue picker covers bug reports, feature requests, and adapter proposals.

## Changes
- Adds `.github/ISSUE_TEMPLATE/adapter_proposal.yml` with backend, use case, implementation notes, and willingness fields.
- Keeps existing `bug_report.yml`, `feature_request.yml`, and `config.yml`.

## Verification
- Template follows the existing YAML form format used by the repo.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a GitHub issue form for proposing new storage adapters.
- Collects the proposed backend, self-hosting use case, implementation notes, and contributor willingness.
- Categorizes submitted proposals with the `enhancement` and `adapter` labels.
</details>

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge.

The new issue form uses valid GitHub issue-form structure and no concrete blocking or non-blocking defect was established.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/adapter_proposal.yml | Adds a valid issue-form template consistent with the repository's existing issue-template structure; no actionable defects were identified. |

<sub>Reviews (1): Last reviewed commit: ["feat: add adapter proposal issue templat..."](https://github.com/ishannaik/cloakbin/commit/0b05ae82c035b89e5a24dd18444282f9aac5bdab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51479923)</sub>

<!-- /greptile_comment -->