### PR TITLE
feat: add line numbers to paste viewer

### DIFF
--- a/src/routes/p/[id]/+page.svelte
+++ b/src/routes/p/[id]/+page.svelte
@@ -18,7 +18,7 @@
 		espresso,
 		noctisLilac
 	} from 'thememirror';
-	import { EditorView } from '@codemirror/view';
+	import { EditorView, lineNumbers } from '@codemirror/view';
 	import logo from '$lib/assets/logo.svg';
 	import { Lock, Copy, Plus, Check, Files, Share2, Key, Flame, Settings } from 'lucide-svelte';
 	import ShortcutsModal from '$lib/components/ShortcutsModal.svelte';
@@ -721,7 +721,7 @@
 				value={content}
 				lang={languageExtension}
 				theme={currentTheme}
-				extensions={[EditorView.lineWrapping, EditorView.editable.of(false)]}
+				extensions={[EditorView.lineWrapping, EditorView.editable.of(false), lineNumbers()]}
 				styles={{
 					'&': {
 						height: '100%',


### PR DESCRIPTION
Part of #162.

## Summary
Adds a CodeMirror line-number gutter to the read-only paste viewer.

## Changes
- Imports `lineNumbers` from `@codemirror/view`.
- Adds `lineNumbers()` to the success-state viewer extensions.

## Follow-up
Clickable line anchors and highlight/scroll behavior are still separate work, so this PR intentionally does not close #162 yet.

## Verification
- `pnpm check`: 0 errors (8 pre-existing warnings).
- `pnpm test`: 47 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added line numbers to the read-only paste viewer for easier code navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds CodeMirror’s built-in line-number gutter to the read-only paste viewer.
- Imports `lineNumbers` from `@codemirror/view`.
- Enables line numbers in the viewer’s success-state extensions.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/routes/p/[id]/+page.svelte | Adds the CodeMirror line-number extension to the read-only paste viewer without changing paste loading, decryption, or editing behavior. |

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/ishannaik/cloakbin/commit/bdf8178fdcbdced3aa5ee71315311e3c3b397832) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51480631)</sub>

<!-- /greptile_comment -->