### PR TITLE
Document HTTP API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,158 @@
+# API documentation
+
+This document describes the HTTP API endpoints for creating, retrieving, and
+burning encrypted pastes.
+
+## Encryption
+
+The server stores and returns ciphertext for pastes without receiving the
+decryption key or password. Content is encrypted on the client before being
+sent to the server.
+
+## POST `/api/paste`
+
+Creates a new encrypted paste.
+
+### Request body
+
+```json
+{
+  "content": "string",
+  "expiry": "1h | 24h | 7d",
+  "salt": "string (optional)",
+  "burnAfterRead": "boolean (optional)",
+  "language": "string (optional)"
+}
+```
+
+### Response body
+
+**201 Created**
+
+```json
+{
+  "id": "string"
+}
+```
+
+### Error codes
+
+| Code | Error body                                                 |
+| ---- | ---------------------------------------------------------- |
+| 400  | `Invalid JSON in request body`                             |
+| 400  | `Content must be a string`                                 |
+| 400  | `Content cannot be empty`                                  |
+| 400  | `Expiry must be one of: "1h", "24h", "7d"`                 |
+| 413  | `Content exceeds maximum size of ${MAX_PASTE_BYTES} bytes` |
+| 429  | `Too many requests`                                        |
+| 500  | `result.error`                                             |
+| 500  | `Internal server error`                                    |
+
+### Rate limits
+
+- 10 requests per minute.
+
+### curl example
+
+```bash
+curl -X POST https://oss.cloakbin.com/api/paste \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "<pre-encrypted-ciphertext>",
+    "expiry": "24h"
+  }'
+```
+
+In this example, `content` is a placeholder. The server accepts any non-empty
+string and does not check the ciphertext format.
+
+## GET `/api/paste/[id]`
+
+Retrieves an encrypted paste by ID.
+
+### Request body
+
+There is no request body.
+
+### Response body
+
+**200 OK**
+
+```json
+{
+  "content": "string",
+  "createdAt": "string",
+  "expiresAt": "string",
+  "hasPassword": "boolean",
+  "salt": "string",
+  "burnAfterRead": "boolean",
+  "language": "string"
+}
+```
+
+### Error codes
+
+| Code | Error body                                                 |
+| ---- | ---------------------------------------------------------- |
+| 400  | `Invalid paste ID`                                         |
+| 404  | `Paste not found`                                          |
+| 404  | `Paste has expired`                                        |
+| 429  | `Too many requests`                                        |
+| 500  | `result.error`                                             |
+| 500  | `Internal server error`                                    |
+
+### Rate limits
+
+- 60 requests per minute.
+
+### curl example
+
+```bash
+curl https://oss.cloakbin.com/api/paste/<id>
+```
+
+## POST `/api/paste/[id]/burn`
+
+Ensures burn-after-read pastes can only be viewed once. The paste is deleted
+from the database in the same operation that returns its content, preventing
+multiple views.
+
+### Request body
+
+There is no request body.
+
+### Response body
+
+**200 OK**
+
+```json
+{
+  "content": "string",
+  "createdAt": "string",
+  "expiresAt": "string",
+  "hasPassword": "boolean",
+  "salt": "string",
+  "burnAfterRead": "boolean",
+  "language": "string"
+}
+```
+
+### Error codes
+
+| Code | Error body                                                 |
+| ---- | ---------------------------------------------------------- |
+| 400  | `Invalid paste ID`                                         |
+| 404  | `Paste not found`                                          |
+| 429  | `Too many requests`                                        |
+| 500  | `result.error`                                             |
+| 500  | `Internal server error`                                    |
+
+### Rate limits
+
+- 100 requests per minute (default rate limit).
+
+### curl example
+
+```bash
+curl -X POST https://oss.cloakbin.com/api/paste/<id>/burn
+```

--- a/docs/API.md
+++ b/docs/API.md
@@ -9,6 +9,13 @@ The server stores and returns ciphertext for pastes without receiving the
 decryption key or password. Content is encrypted on the client before being
 sent to the server.
 
+## Salt and `hasPassword`
+
+The client generates a random 16-byte salt (standard base64) for
+password-protected pastes and includes it in the create request. The server
+sets `hasPassword` to `true` whenever `salt` is non-empty. Passwordless pastes
+omit `salt` from responses and return `hasPassword: false`.
+
 ## POST `/api/paste`
 
 Creates a new encrypted paste.
@@ -71,7 +78,10 @@ string and does not check the ciphertext format.
 
 ## GET `/api/paste/[id]`
 
-Retrieves an encrypted paste by ID.
+Retrieves an encrypted paste by ID. This endpoint never deletes the paste,
+including for burn-after-read pastes. To consume a burn-after-read paste,
+use `POST /api/paste/[id]/burn` instead, which returns the content and deletes
+the paste in the same operation.
 
 ### Request body
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -37,16 +37,19 @@ Creates a new encrypted paste.
 
 ### Error codes
 
-| Code | Error message |
+Errors are returned as JSON objects with an `error` field:
+
+| Code | Error body |
 | ---- | ---------------------------------------------------------- |
-| 400  | `Invalid JSON in request body` |
-| 400  | `Content must be a string` |
-| 400  | `Content cannot be empty` |
-| 400  | `Expiry must be one of: "1h", "24h", "7d"` |
-| 413  | `Content exceeds maximum size of <max bytes> bytes` |
-| 429  | `Too many requests` |
-| 500  | `<error message from result.error>` |
-| 500  | `Internal server error` |
+| 400  | `{"error": "Invalid JSON in request body"}` |
+| 400  | `{"error": "Content must be a string"}` |
+| 400  | `{"error": "Content cannot be empty"}` |
+| 400  | `{"error": "Expiry must be one of: \"1h\", \"24h\", \"7d\""}` |
+| 400  | `{"error": "burnAfterRead must be a boolean"}` |
+| 413  | `{"error": "Content exceeds maximum size of <max bytes> bytes"}` |
+| 429  | `{"error": "Too many requests", "retryAfter": <seconds>}` |
+| 500  | `{"error": "<error message from result.error>"}` |
+| 500  | `{"error": "Internal server error"}` |
 
 ### Rate limits
 
@@ -84,7 +87,7 @@ There is no request body.
   "createdAt": "YYYY-MM-DDTHH:mm:ss.sssZ",
   "expiresAt": "YYYY-MM-DDTHH:mm:ss.sssZ",
   "hasPassword": "boolean",
-  "salt": "string",
+  "salt": "string (omitted for passwordless pastes)",
   "burnAfterRead": "boolean",
   "language": "string"
 }
@@ -92,14 +95,16 @@ There is no request body.
 
 ### Error codes
 
-| Code | Error message |
+Errors are returned as JSON objects with an `error` field:
+
+| Code | Error body |
 | ---- | ---------------------------------------------------------- |
-| 400  | `Invalid paste ID` |
-| 404  | `Paste not found` |
-| 404  | `Paste has expired` |
-| 429  | `Too many requests` |
-| 500  | `<error message from result.error>` |
-| 500  | `Internal server error` |
+| 400  | `{"error": "Invalid paste ID"}` |
+| 404  | `{"error": "Paste not found"}` |
+| 404  | `{"error": "Paste has expired"}` |
+| 429  | `{"error": "Too many requests", "retryAfter": <seconds>}` |
+| 500  | `{"error": "<error message from result.error>"}` |
+| 500  | `{"error": "Internal server error"}` |
 
 ### Rate limits
 
@@ -131,7 +136,7 @@ There is no request body.
   "createdAt": "YYYY-MM-DDTHH:mm:ss.sssZ",
   "expiresAt": "YYYY-MM-DDTHH:mm:ss.sssZ",
   "hasPassword": "boolean",
-  "salt": "string",
+  "salt": "string (omitted for passwordless pastes)",
   "burnAfterRead": "boolean",
   "language": "string"
 }
@@ -139,17 +144,19 @@ There is no request body.
 
 ### Error codes
 
-| Code | Error message |
+Errors are returned as JSON objects with an `error` field:
+
+| Code | Error body |
 | ---- | ---------------------------------------------------------- |
-| 400  | `Invalid paste ID` |
-| 404  | `Paste not found` |
-| 429  | `Too many requests` |
-| 500  | `<error message from result.error>` |
-| 500  | `Internal server error` |
+| 400  | `{"error": "Invalid paste ID"}` |
+| 404  | `{"error": "Paste not found"}` |
+| 429  | `{"error": "Too many requests", "retryAfter": <seconds>}` |
+| 500  | `{"error": "<error message from result.error>"}` |
+| 500  | `{"error": "Internal server error"}` |
 
 ### Rate limits
 
-- 100 requests per minute (default rate limit).
+- 60 requests per minute (same bucket as paste reads).
 
 ### curl example
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -37,16 +37,16 @@ Creates a new encrypted paste.
 
 ### Error codes
 
-| Code | Error body                                                 |
+| Code | Error message |
 | ---- | ---------------------------------------------------------- |
-| 400  | `Invalid JSON in request body`                             |
-| 400  | `Content must be a string`                                 |
-| 400  | `Content cannot be empty`                                  |
-| 400  | `Expiry must be one of: "1h", "24h", "7d"`                 |
-| 413  | `Content exceeds maximum size of ${MAX_PASTE_BYTES} bytes` |
-| 429  | `Too many requests`                                        |
-| 500  | `result.error`                                             |
-| 500  | `Internal server error`                                    |
+| 400  | `Invalid JSON in request body` |
+| 400  | `Content must be a string` |
+| 400  | `Content cannot be empty` |
+| 400  | `Expiry must be one of: "1h", "24h", "7d"` |
+| 413  | `Content exceeds maximum size of <max bytes> bytes` |
+| 429  | `Too many requests` |
+| 500  | `<error message from result.error>` |
+| 500  | `Internal server error` |
 
 ### Rate limits
 
@@ -92,14 +92,14 @@ There is no request body.
 
 ### Error codes
 
-| Code | Error body                                                 |
+| Code | Error message |
 | ---- | ---------------------------------------------------------- |
-| 400  | `Invalid paste ID`                                         |
-| 404  | `Paste not found`                                          |
-| 404  | `Paste has expired`                                        |
-| 429  | `Too many requests`                                        |
-| 500  | `result.error`                                             |
-| 500  | `Internal server error`                                    |
+| 400  | `Invalid paste ID` |
+| 404  | `Paste not found` |
+| 404  | `Paste has expired` |
+| 429  | `Too many requests` |
+| 500  | `<error message from result.error>` |
+| 500  | `Internal server error` |
 
 ### Rate limits
 
@@ -139,13 +139,13 @@ There is no request body.
 
 ### Error codes
 
-| Code | Error body                                                 |
+| Code | Error message |
 | ---- | ---------------------------------------------------------- |
-| 400  | `Invalid paste ID`                                         |
-| 404  | `Paste not found`                                          |
-| 429  | `Too many requests`                                        |
-| 500  | `result.error`                                             |
-| 500  | `Internal server error`                                    |
+| 400  | `Invalid paste ID` |
+| 404  | `Paste not found` |
+| 429  | `Too many requests` |
+| 500  | `<error message from result.error>` |
+| 500  | `Internal server error` |
 
 ### Rate limits
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -81,8 +81,8 @@ There is no request body.
 ```json
 {
   "content": "string",
-  "createdAt": "string",
-  "expiresAt": "string",
+  "createdAt": "YYYY-MM-DDTHH:mm:ss.sssZ",
+  "expiresAt": "YYYY-MM-DDTHH:mm:ss.sssZ",
   "hasPassword": "boolean",
   "salt": "string",
   "burnAfterRead": "boolean",
@@ -128,8 +128,8 @@ There is no request body.
 ```json
 {
   "content": "string",
-  "createdAt": "string",
-  "expiresAt": "string",
+  "createdAt": "YYYY-MM-DDTHH:mm:ss.sssZ",
+  "expiresAt": "YYYY-MM-DDTHH:mm:ss.sssZ",
   "hasPassword": "boolean",
   "salt": "string",
   "burnAfterRead": "boolean",


### PR DESCRIPTION
<!--
Thanks for contributing to CloakBin. Keep PRs focused: one concern per PR.
-->

## What & why

**What**

Added API documentation for the paste API.

**Why**

Provide clear, accurate documentation so developers can understand how to use the API and interpret its responses.

Closes [issue #82](https://github.com/Ishannaik/CloakBin/issues/82)

## Type of change

- [ ] Bug fix
- [ ] Feature / enhancement
- [ ] CLI
- [x] Refactor / docs / chore

## Testing

<!-- What you ran and what you clicked through. -->

```
# pnpm check / pnpm lint output
```

## Checklist

- [ ] `pnpm check` and `pnpm lint` pass
- [ ] No real secrets or live paste URLs in the diff, tests, or screenshots
- [ ] **Touches crypto or key handling?** The key stays in the URL fragment and never reaches the server, the network tab proves it, and the change is called out above
- [ ] UI changes tested at desktop width and around 390px
- [ ] No new runtime dependency, or the PR explains why one is needed

---

Stuck on a review comment or want to talk through an approach? [Discord](https://discord.gg/KKvtRhQvRv).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added API documentation for creating, retrieving, and burning encrypted pastes.
  * Documented client-side encryption, request and response formats, validation rules, error codes, rate limits, and command-line examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds HTTP API documentation for creating, retrieving, and burning encrypted pastes.
- Documents encryption and password-salt behavior.
- Defines request, success, and error response formats.
- Adds rate-limit information and curl examples.
- The passwordless response guarantee does not cover the API’s accepted empty-string salt state.
</details>

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the documented passwordless response contract is reconciled with accepted empty-string salts.

The API accepts an empty salt, records the paste as passwordless, and later returns that empty salt, contradicting the new guarantee that passwordless responses omit the field.

**Files Needing Attention:** docs/API.md

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/API.md | Adds comprehensive API documentation, but its unconditional salt-omission contract conflicts with responses produced after an empty-string salt is accepted. |

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Adocs%2FAPI.md%3A15-17%0A**Empty%20salts%20violate%20omission%20contract**%0A%0AWhen%20a%20create%20request%20supplies%20%60%22salt%22%3A%20%22%22%60%2C%20the%20server%20records%20the%20paste%20as%20passwordless%20but%20retains%20the%20empty%20salt%20in%20GET%20and%20burn%20responses%2C%20contradicting%20the%20documented%20guarantee%20that%20passwordless%20responses%20omit%20%60salt%60%20and%20causing%20clients%20that%20validate%20this%20contract%20to%20reject%20or%20misclassify%20the%20response.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=220&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ishannaik%2Fcloakbin%22%20on%20the%20existing%20branch%20%22jessie212%2Fdocs-HTTP-API%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22jessie212%2Fdocs-HTTP-API%22.%0A%0A%23%23%23%20Issue%201%0Adocs%2FAPI.md%3A15-17%0A**Empty%20salts%20violate%20omission%20contract**%0A%0AWhen%20a%20create%20request%20supplies%20%60%22salt%22%3A%20%22%22%60%2C%20the%20server%20records%20the%20paste%20as%20passwordless%20but%20retains%20the%20empty%20salt%20in%20GET%20and%20burn%20responses%2C%20contradicting%20the%20documented%20guarantee%20that%20passwordless%20responses%20omit%20%60salt%60%20and%20causing%20clients%20that%20validate%20this%20contract%20to%20reject%20or%20misclassify%20the%20response.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ishannaik%2Fcloakbin&pr=220&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Adocs%2FAPI.md%3A15-17%0A**Empty%20salts%20violate%20omission%20contract**%0A%0AWhen%20a%20create%20request%20supplies%20%60%22salt%22%3A%20%22%22%60%2C%20the%20server%20records%20the%20paste%20as%20passwordless%20but%20retains%20the%20empty%20salt%20in%20GET%20and%20burn%20responses%2C%20contradicting%20the%20documented%20guarantee%20that%20passwordless%20responses%20omit%20%60salt%60%20and%20causing%20clients%20that%20validate%20this%20contract%20to%20reject%20or%20misclassify%20the%20response.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=220&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
docs/API.md:15-17
**Empty salts violate omission contract**

When a create request supplies `"salt": ""`, the server records the paste as passwordless but retains the empty salt in GET and burn responses, contradicting the documented guarantee that passwordless responses omit `salt` and causing clients that validate this contract to reject or misclassify the response.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["docs: document salt/hasPassword contract..."](https://github.com/ishannaik/cloakbin/commit/4a53c201fe233668cb15cf3da2187400c7f97703) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52000874)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->