### PR TITLE
docs: mention health endpoint in llms.txt

### DIFF
--- a/static/llms.txt
+++ b/static/llms.txt
@@ -29,6 +29,7 @@ CloakBin is a privacy-first pastebin that uses client-side encryption. Your data
 - Password protection: PBKDF2 key derivation
 - Framework: SvelteKit
 - Database: MongoDB with TTL indexes
+- Health check: GET /api/health
 
 ## Privacy Commitment
 


### PR DESCRIPTION
Closes #229.

## What & why

Documents the existing public `GET /api/health` endpoint in `static/llms.txt`, so agents can discover the health route already exposed by CloakBin. The change does not list any admin route.

## Type of change

- [ ] Bug fix
- [ ] Feature / enhancement
- [ ] CLI
- [x] Refactor / docs / chore

## Testing

```text
pnpm check          PASS — 0 errors, 8 existing warnings
pnpm test           PASS — 7 files, 58 tests
pnpm type-coverage  PASS — 93.75% (threshold: 93%)
DB_TYPE=memory pnpm build  PASS
LLMS text contract  PASS — UTF-8, one exact public health route, one-file/one-line diff
```

The repository-wide `pnpm lint` currently reports 21 errors and 52 warnings in existing source files; ESLint does not inspect the changed text file. `pnpm format:check` currently reports 99 existing files, while Prettier has no inferred parser for `static/llms.txt`. I have left those unrelated baseline files untouched.

## Checklist

- [ ] `pnpm check` and `pnpm lint` pass — `check` passes; the existing lint baseline is disclosed above
- [x] No real secrets or live paste URLs in the diff, tests, or screenshots
- [x] Crypto and key handling are not touched
- [x] No UI changes
- [x] No new runtime dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the health-check endpoint to the technical details documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Documents CloakBin’s existing public health-check endpoint for agents and other consumers of `llms.txt`.
- Adds `GET /api/health` to the Technical Details section.
- Does not modify runtime behavior, dependencies, or administrative route documentation.
</details>


<h3>Confidence Score: 5/5</h3>

The documentation-only change appears safe to merge.

The documented method and path match the existing public health route, and no actionable correctness, security, or quality issue remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| static/llms.txt | Accurately adds the existing public `GET /api/health` route to the agent-facing documentation. |

<sub>Reviews (1): Last reviewed commit: ["docs: document health check in llms.txt"](https://github.com/ishannaik/cloakbin/commit/186e8513d7b5f08e27adc2a4decae9ad399cd66e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55967195)</sub>

<!-- /greptile_comment -->